### PR TITLE
Nullish fix for transition slider default

### DIFF
--- a/src/pages/Device/Transition.tsx
+++ b/src/pages/Device/Transition.tsx
@@ -58,7 +58,7 @@ const TransitionCard = ({ virtual, style }: any) => {
         <FormControl sx={{ marginRight: '0.5rem', flex: 1 }}>
           <BladeFrame title="Duration">
             <Slider
-              defaultValue={transition_time || schemas?.transition_time.default}
+              defaultValue={transition_time ?? schemas?.transition_time.default}
               onChangeCommitted={onSliderChange}
               aria-labelledby="discrete-slider"
               step={0.1}


### PR DESCRIPTION
Replace || OR with ?? Nullish on transition slider default substantiation

|| operator treats 0 as false, and therefore will assign default to value, instead of 0

Use ?? Nullish check

Relevant example

https://www.youtube.com/watch?v=GbHVrOObGcs

Checked current support via

https://caniuse.com/?search=nullish

Looks good to me, bearing in mind, this I have minimal JS exposure

Tested via repeated value changes

Implication is this may be a common issue in the code base...

I did consider changing line 

            defaultValue={transition_mode || schemas?.transition_mode.default}

To be the same, but assuming there is no valid zero dur to string / enum, so no similar risk, though it may be good practice?