### PR TITLE
Fix Spotify Auth, finally..

### DIFF
--- a/src/pages/Integrations/Spotify/SpotifyLoginRedirect.tsx
+++ b/src/pages/Integrations/Spotify/SpotifyLoginRedirect.tsx
@@ -2,6 +2,10 @@
 /* eslint-disable no-return-assign */
 /* eslint-disable prettier/prettier */
 import isElectron from 'is-electron';
+import {
+  finishAuth,
+  refreshAuth
+} from '../../../utils/spotifyProxies'
 
 const baseURL = isElectron() ? 'http://localhost:8888' : window.location.href.split('/#')[0].replace(/\/+$/, '') || 'http://localhost:8888';
 const storedURL = window.localStorage.getItem('ledfx-host');
@@ -11,6 +15,8 @@ const SpotifyLoginRedirect = () => {
     'Spotify-Token',
     window.location.search.replace('?code=', '')
   );
+  finishAuth()
+  refreshAuth()
   setTimeout(() => window.location.href = `${process.env.NODE_ENV === 'production' ? storedURL || baseURL : 'http://localhost:3000' }/#/Integrations?`, 200 ); // Redirect to homepage after 3 sec
   return (
     <div style={{ margin: '6rem auto' }}>Successfully logged in with Spotify...</div>


### PR DESCRIPTION
Summary: no need to refresh the page to get it to work. 

First time login access_token used to require a refresh of the page in order to detect token. Now that is fixed that seemless login. bug fixed. FINALLY
RefreshAuth now refreshes if expired, no need to refresh page. 
