### PR TITLE
Added Launchkey support

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "react-webcam": "^7.2.0",
     "react-zoom-pan-pinch": "^3.7.0",
     "reactour": "^1.19.2",
+    "rimraf": "^6.0.1",
     "sockette": "^2.0.6",
     "strip-ansi": "7.1.0",
     "styled-components": "^6.1.13",
@@ -101,7 +102,7 @@
     "build:default": "GENERATE_SOURCEMAP=false CI=false craco build",
     "prebuild": "node -e \"let pkg=require('./package.json'); pkg.homepage='/'; require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2));\"",
     "postbuild": "run-script-os",
-    "postbuild:win32": "node -e \"let pkg=require('./package.json'); pkg.homepage='.'; require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2));\" && del /q build\\app && del /q build\\preload.cjs && del /q build\\renderer.js && del /q build\\electron.js",
+    "postbuild:win32": "node -e \"let pkg=require('./package.json'); pkg.homepage='.'; require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2));\" && rimraf build/app && rimraf build/preload.cjs && rimraf build/renderer.js && rimraf build/electron.js",
     "postbuild:default": "node -e \"let pkg=require('./package.json'); pkg.homepage='.'; require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2));\" && rm -rf build/app && rm -rf build/preload.cjs && rm -rf build/renderer.js && rm -rf build/electron.js",
     "buildhass": "GENERATE_SOURCEMAP=false CI=false craco build",
     "prebuildhass": "node -e \"let pkg=require('./package.json'); pkg.homepage='./'; require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2));\"",
@@ -111,7 +112,7 @@
     "postbuildgh": "rm -rf build/app && rm -rf build/preload.cjs && rm -rf build/renderer.js && rm -rf build/electron.js",
     "buildledfx": "cross-env GENERATE_SOURCEMAP=false PUBLIC_URL=/ CI=false craco build",
     "prebuildledfx": "node -e \"let pkg=require('./package.json'); pkg.homepage='/'; require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2));\"",
-    "postbuildledfx": "node -e \"let pkg=require('./package.json'); pkg.homepage='.'; require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2));\" && del /q /s \"build\\app\" && rmdir /q /s \"build\\app\" && del /q \"build\\preload.cjs\" && del /q \"build\\renderer.js\" && del /q \"build\\electron.js\"",
+    "postbuildledfx": "node -e \"let pkg=require('./package.json'); pkg.homepage='.'; require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2));\" && rimraf \"build/app\" && rimraf \"build/preload.cjs\" && rimraf \"build/renderer.js\" && rimraf \"build/electron.js\"",
     "buildandroid": "cross-env REACT_APP_LEDFX_ANDROID=true GENERATE_SOURCEMAP=false PUBLIC_URL=/ CI=false craco build",
     "prebuildandroid": "node -e \"let pkg=require('./package.json'); pkg.homepage='/'; require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2));\"",
     "postbuildandroid": "node -e \"let pkg=require('./package.json'); pkg.homepage='.'; require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2));\" && rm -rf build/app && rm -f build/preload.cjs && rm -f build/renderer.js && rm -f build/electron.js",
@@ -295,4 +296,4 @@
       ]
     }
   }
-}
+}

--- a/src/components/Midi/LaunchpadButtonMap.tsx
+++ b/src/components/Midi/LaunchpadButtonMap.tsx
@@ -247,16 +247,20 @@ const LaunchpadButtonMap = ({
     if (!output) return
     switch (mode) {
       case 'programmer':
-        output.send([0xf0, 0x00, 0x20, 0x29, 0x02, 0x0c, 0x0e, 0x01, 0xf7])
+        if ('programmer' in lp.command)
+          output.send(lp.command?.programmer ?? [0xf0, 0x00, 0x20, 0x29, 0x02, 0x0c, 0x0e, 0x01, 0xf7])
         break
       case 'live':
-        output.send([0xf0, 0x00, 0x20, 0x29, 0x02, 0x0c, 0x0e, 0x00, 0xf7])
+        if ('live' in lp.command)
+          output.send(lp.command?.live ?? [0xf0, 0x00, 0x20, 0x29, 0x02, 0x0c, 0x0e, 0x00, 0xf7])
         break
       case 'standalone':
-        output.send([0xf0, 0x00, 0x20, 0x29, 0x02, 0x0c, 0x10, 0x00, 0xf7])
+        if ('standalone' in lp.command)
+          output.send(lp.command?.standalone ?? [0xf0, 0x00, 0x20, 0x29, 0x02, 0x0c, 0x10, 0x00, 0xf7])
         break
       case 'daw':
-        output.send([0xf0, 0x00, 0x20, 0x29, 0x02, 0x0c, 0x10, 0x01, 0xf7])
+        if ('daw' in lp.command)
+          output.send(lp.command?.daw ?? [0xf0, 0x00, 0x20, 0x29, 0x02, 0x0c, 0x10, 0x01, 0xf7])
         break
       default:
         break
@@ -302,8 +306,18 @@ const LaunchpadButtonMap = ({
       >
         <Stack direction={'row'} alignItems={'center'} spacing={2}>
           <Stack direction={'row'} alignItems={'center'} spacing={0}>
-            <Button onClick={() => setMode('programmer')}>Programmer</Button>
-            <Button onClick={() => setMode('live')}>Live</Button>
+            {'programmer' in lp.command && (
+              <Button onClick={() => setMode('programmer')}>Programmer</Button>
+            )}
+            {'live' in lp.command && (
+              <Button onClick={() => setMode('live')}>Live</Button>
+            )}
+            {'standalone' in lp.command && (
+              <Button onClick={() => setMode('standalone')}>Standalone</Button>
+            )}
+            {'daw' in lp.command && (
+              <Button onClick={() => setMode('daw')}>DAW</Button>
+            )}
           </Stack>
         </Stack>
         <Stack direction={'row'} alignItems={'center'} spacing={0}>

--- a/src/components/Midi/MidiListener.tsx
+++ b/src/components/Midi/MidiListener.tsx
@@ -171,7 +171,9 @@ const MIDIListener = () => {
           const output = outputs[outputs.length - 1]
           const lp = MidiDevices[midiType][midiModel].fn
 
-          Object.entries(midiMapping).forEach(([_key, value]) => {
+          type midiMap = { buttonNumber: number, command: string|undefined }
+
+          function setMap(value: midiMap) {
             const buttonNumber = value.buttonNumber
             if (!value.command || value.command === 'none' || buttonNumber === -1) {
               if (output && buttonNumber !== -1) {
@@ -181,6 +183,14 @@ const MIDIListener = () => {
                   console.log('Error sending MIDI message:', error)
                 }
               }
+            }
+          }
+          Object.values(midiMapping)
+          .forEach((value: midiMap|{ [k: number]: midiMap }) => {
+            if (!('buttonNumber' in value)) {
+              Object.values(value).forEach(setMap);
+            } else {
+              setMap(value)
             }
           })
 

--- a/src/utils/MidiDevices/LaunchPadDevice.ts
+++ b/src/utils/MidiDevices/LaunchPadDevice.ts
@@ -60,6 +60,9 @@ export interface LaunchpadSDevice {
     commandType: string
     commandColor: string
   }
+  command: {
+    ledOn: (number | string)[]
+  }
   fn: {
     ledOff: (buttonNumber: number) => number[]
     ledOn: (buttonNumber: number, color: keyof typeof lpsColors | number) => number[]

--- a/src/utils/MidiDevices/LaunchkeyDevice.ts
+++ b/src/utils/MidiDevices/LaunchkeyDevice.ts
@@ -1,0 +1,71 @@
+/* eslint-disable no-unused-vars */
+import { lpColors } from './LaunchpadX/lpColors'
+
+export interface LaunchkeyMK3Device {
+  buttonNumbers: number[][]
+  colors: Record<string, number>
+  commonColors: Record<string, number>
+  globalColors: {
+    sceneActiveType: string
+    sceneActiveColor: string
+    sceneInactiveType: string
+    sceneInactiveColor: string
+    commandType: string
+    commandColor: string
+  }
+  command: {
+    standalone: number[]
+    daw: number[]
+    ledOn: (number | string)[]
+    ledFlash: (number | string)[]
+    ledPulse: (number | string)[]
+    text: (number | string)[]
+    stopText: number[]
+  }
+  fn: {
+    ledOff: (buttonNumber: number) => number[]
+    ledOn: (
+      buttonNumber: number,
+      color: keyof typeof lpColors | number,
+      mode?: 'solid' | 'flash' | 'pulse'
+    ) => number[]
+    ledSolid: (buttonNumber: number, color: keyof typeof lpColors | number) => number[]
+    ledFlash: (buttonNumber: number, color: keyof typeof lpColors | number) => number[]
+    ledPulse: (buttonNumber: number, color: keyof typeof lpColors | number) => number[]
+    text: (text: string) => number[]
+  }
+}
+
+export interface LaunchkeyMiniMK3Device {
+  buttonNumbers: number[][]
+  colors: Record<string, number>
+  commonColors: Record<string, number>
+  globalColors: {
+    sceneActiveType: string
+    sceneActiveColor: string
+    sceneInactiveType: string
+    sceneInactiveColor: string
+    commandType: string
+    commandColor: string
+  }
+  command: {
+    standalone: number[]
+    daw: number[]
+    ledOn: (number | string)[]
+    ledFlash: (number | string)[]
+    ledPulse: (number | string)[]
+  }
+  fn: {
+    ledOff: (buttonNumber: number) => number[]
+    ledOn: (
+      buttonNumber: number,
+      color: keyof typeof lpColors | number,
+      mode?: 'solid' | 'flash' | 'pulse'
+    ) => number[]
+    ledSolid: (buttonNumber: number, color: keyof typeof lpColors | number) => number[]
+    ledFlash: (buttonNumber: number, color: keyof typeof lpColors | number) => number[]
+    ledPulse: (buttonNumber: number, color: keyof typeof lpColors | number) => number[]
+  }
+}
+
+export type LaunchkeyDevice = LaunchkeyMK3Device | LaunchkeyMiniMK3Device;

--- a/src/utils/MidiDevices/LaunchkeyDevice.ts
+++ b/src/utils/MidiDevices/LaunchkeyDevice.ts
@@ -68,4 +68,4 @@ export interface LaunchkeyMiniMK3Device {
   }
 }
 
-export type LaunchkeyDevice = LaunchkeyMK3Device | LaunchkeyMiniMK3Device;
+export type LaunchkeyDevice = LaunchkeyMK3Device | LaunchkeyMiniMK3Device

--- a/src/utils/MidiDevices/LaunchkeyMK3/LaunchkeyMK3.ts
+++ b/src/utils/MidiDevices/LaunchkeyMK3/LaunchkeyMK3.ts
@@ -3,8 +3,15 @@ import { lpColors, lpCommonColors } from '../LaunchpadX/lpColors'
 
 export const LaunchkeyMK3: LaunchkeyMK3Device = {
   buttonNumbers: [
-    [40, 41, 42, 43, 48, 49, 50, 51],
-    [36, 37, 38, 39, 44, 45, 46, 47],
+    [40, 41, 42, 43, 48, 49, 50, 51, -1],
+    [36, 37, 38, 39, 44, 45, 46, 47, -1],
+    [-1, -1, -1, -1, -1, -1, -1, -1, -1],
+    [-1, -1, -1, -1, -1, -1, -1, -1, -1],
+    [-1, -1, -1, -1, -1, -1, -1, -1, -1],
+    [-1, -1, -1, -1, -1, -1, -1, -1, -1],
+    [-1, -1, -1, -1, -1, -1, -1, -1, -1],
+    [-1, -1, -1, -1, -1, -1, -1, -1, -1],
+    [-1, -1, -1, -1, -1, -1, -1, -1, -1]
   ],
   colors: lpColors,
   commonColors: lpCommonColors,
@@ -22,9 +29,7 @@ export const LaunchkeyMK3: LaunchkeyMK3Device = {
     ledOn: [0x99, 'buttonNumber', 'color'],
     ledFlash: [0x9a, 'buttonNumber', 'color'],
     ledPulse: [0x9b, 'buttonNumber', 'color'],
-    text: [
-      240, 0, 32, 41, 2, 15, 4, 'row', 'character', 'character', 247
-    ],
+    text: [240, 0, 32, 41, 2, 15, 4, 'row', 'character', 'character', 247],
     stopText: [240, 0, 32, 41, 2, 15, 6, 247]
   },
   fn: {

--- a/src/utils/MidiDevices/LaunchkeyMK3/LaunchkeyMK3.ts
+++ b/src/utils/MidiDevices/LaunchkeyMK3/LaunchkeyMK3.ts
@@ -3,14 +3,14 @@ import { lpColors, lpCommonColors } from '../LaunchpadX/lpColors'
 
 export const LaunchkeyMK3: LaunchkeyMK3Device = {
   buttonNumbers: [
-    [40, 41, 42, 43, 48, 49, 50, 51, -1],
+    [-1, -1, -1, -1, -1, -1, -1, -1, -1],
+    [-1, -1, -1, -1, -1, -1, -1, -1, -1],
+    [-1, -1, -1, -1, -1, -1, -1, -1, -1],
+    [-1, -1, -1, -1, -1, -1, -1, -1, -1],
+    [-1, -1, -1, -1, -1, -1, -1, -1, -1],
+    [-1, -1, -1, -1, -1, -1, -1, -1, -1],
     [36, 37, 38, 39, 44, 45, 46, 47, -1],
-    [-1, -1, -1, -1, -1, -1, -1, -1, -1],
-    [-1, -1, -1, -1, -1, -1, -1, -1, -1],
-    [-1, -1, -1, -1, -1, -1, -1, -1, -1],
-    [-1, -1, -1, -1, -1, -1, -1, -1, -1],
-    [-1, -1, -1, -1, -1, -1, -1, -1, -1],
-    [-1, -1, -1, -1, -1, -1, -1, -1, -1],
+    [40, 41, 42, 43, 48, 49, 50, 51, -1],
     [-1, -1, -1, -1, -1, -1, -1, -1, -1]
   ],
   colors: lpColors,
@@ -25,7 +25,7 @@ export const LaunchkeyMK3: LaunchkeyMK3Device = {
   },
   command: {
     standalone: [0x9f, 0x0c, 0x00],
-    daw: [0x9f, 0x0c, 0xf7],
+    daw: [0x9f, 0x0c, 0x7f],
     ledOn: [0x99, 'buttonNumber', 'color'],
     ledFlash: [0x9a, 'buttonNumber', 'color'],
     ledPulse: [0x9b, 'buttonNumber', 'color'],

--- a/src/utils/MidiDevices/LaunchkeyMK3/LaunchkeyMK3.ts
+++ b/src/utils/MidiDevices/LaunchkeyMK3/LaunchkeyMK3.ts
@@ -1,0 +1,68 @@
+import { LaunchkeyMK3Device } from '../LaunchkeyDevice'
+import { lpColors, lpCommonColors } from '../LaunchpadX/lpColors'
+
+export const LaunchkeyMK3: LaunchkeyMK3Device = {
+  buttonNumbers: [
+    [40, 41, 42, 43, 48, 49, 50, 51],
+    [36, 37, 38, 39, 44, 45, 46, 47],
+  ],
+  colors: lpColors,
+  commonColors: lpCommonColors,
+  globalColors: {
+    sceneActiveType: 'rgb',
+    sceneActiveColor: 'rgb(0, 255, 0)',
+    sceneInactiveType: 'rgb',
+    sceneInactiveColor: 'rgb(255, 0, 0)',
+    commandType: 'rgb',
+    commandColor: 'rgb(255, 255, 0)'
+  },
+  command: {
+    standalone: [0x9f, 0x0c, 0x00],
+    daw: [0x9f, 0x0c, 0xf7],
+    ledOn: [0x99, 'buttonNumber', 'color'],
+    ledFlash: [0x9a, 'buttonNumber', 'color'],
+    ledPulse: [0x9b, 'buttonNumber', 'color'],
+    text: [
+      240, 0, 32, 41, 2, 15, 4, 'row', 'character', 'character', 247
+    ],
+    stopText: [240, 0, 32, 41, 2, 15, 6, 247]
+  },
+  fn: {
+    ledOff: (buttonNumber: number) => [0x99, buttonNumber, 0x00],
+    ledOn: (
+      buttonNumber: number,
+      color: keyof typeof lpColors | number,
+      mode: 'solid' | 'flash' | 'pulse' = 'solid'
+    ) => [
+      mode === 'pulse' ? 0x9b : mode === 'flash' ? 0x9a : 0x99,
+      buttonNumber,
+      typeof color === 'number' ? color : lpColors[color]
+    ],
+    ledSolid: (buttonNumber: number, color: keyof typeof lpColors | number) => [
+      0x99,
+      buttonNumber,
+      typeof color === 'number' ? color : lpColors[color]
+    ],
+    ledFlash: (buttonNumber: number, color: keyof typeof lpColors | number) => [
+      0x9a,
+      buttonNumber,
+      typeof color === 'number' ? color : lpColors[color]
+    ],
+    ledPulse: (buttonNumber: number, color: keyof typeof lpColors | number) => [
+      0x9b,
+      buttonNumber,
+      typeof color === 'number' ? color : lpColors[color]
+    ],
+    text: (text: string) => [
+      240,
+      0,
+      32,
+      41,
+      2,
+      15,
+      4,
+      ...text.split('').map((char) => char.charCodeAt(0)),
+      247
+    ]
+  }
+}

--- a/src/utils/MidiDevices/LaunchkeyMiniMK3/LaunchkeyMiniMK3.ts
+++ b/src/utils/MidiDevices/LaunchkeyMiniMK3/LaunchkeyMiniMK3.ts
@@ -1,0 +1,53 @@
+import { LaunchkeyMiniMK3Device } from '../LaunchkeyDevice'
+import { lpColors, lpCommonColors } from '../LaunchpadX/lpColors'
+
+export const LaunchkeyMiniMK3: LaunchkeyMiniMK3Device = {
+  buttonNumbers: [
+    [40, 41, 42, 43, 48, 49, 50, 51],
+    [36, 37, 38, 39, 44, 45, 46, 47],
+  ],
+  colors: lpColors,
+  commonColors: lpCommonColors,
+  globalColors: {
+    sceneActiveType: 'rgb',
+    sceneActiveColor: 'rgb(0, 255, 0)',
+    sceneInactiveType: 'rgb',
+    sceneInactiveColor: 'rgb(255, 0, 0)',
+    commandType: 'rgb',
+    commandColor: 'rgb(255, 255, 0)'
+  },
+  command: {
+    standalone: [0x9f, 0x0c, 0x00],
+    daw: [0x9f, 0x0c, 0xf7],
+    ledOn: [0x99, 'buttonNumber', 'color'],
+    ledFlash: [0x9a, 'buttonNumber', 'color'],
+    ledPulse: [0x9b, 'buttonNumber', 'color'],
+  },
+  fn: {
+    ledOff: (buttonNumber: number) => [0x99, buttonNumber, 0x00],
+    ledOn: (
+      buttonNumber: number,
+      color: keyof typeof lpColors | number,
+      mode: 'solid' | 'flash' | 'pulse' = 'solid'
+    ) => [
+      mode === 'pulse' ? 0x9b : mode === 'flash' ? 0x9a : 0x99,
+      buttonNumber,
+      typeof color === 'number' ? color : lpColors[color]
+    ],
+    ledSolid: (buttonNumber: number, color: keyof typeof lpColors | number) => [
+      0x99,
+      buttonNumber,
+      typeof color === 'number' ? color : lpColors[color]
+    ],
+    ledFlash: (buttonNumber: number, color: keyof typeof lpColors | number) => [
+      0x9a,
+      buttonNumber,
+      typeof color === 'number' ? color : lpColors[color]
+    ],
+    ledPulse: (buttonNumber: number, color: keyof typeof lpColors | number) => [
+      0x9b,
+      buttonNumber,
+      typeof color === 'number' ? color : lpColors[color]
+    ],
+  }
+}

--- a/src/utils/MidiDevices/LaunchkeyMiniMK3/LaunchkeyMiniMK3.ts
+++ b/src/utils/MidiDevices/LaunchkeyMiniMK3/LaunchkeyMiniMK3.ts
@@ -3,14 +3,14 @@ import { lpColors, lpCommonColors } from '../LaunchpadX/lpColors'
 
 export const LaunchkeyMiniMK3: LaunchkeyMiniMK3Device = {
   buttonNumbers: [
-    [40, 41, 42, 43, 48, 49, 50, 51, -1],
+    [-1, -1, -1, -1, -1, -1, -1, -1, -1],
+    [-1, -1, -1, -1, -1, -1, -1, -1, -1],
+    [-1, -1, -1, -1, -1, -1, -1, -1, -1],
+    [-1, -1, -1, -1, -1, -1, -1, -1, -1],
+    [-1, -1, -1, -1, -1, -1, -1, -1, -1],
+    [-1, -1, -1, -1, -1, -1, -1, -1, -1],
     [36, 37, 38, 39, 44, 45, 46, 47, -1],
-    [-1, -1, -1, -1, -1, -1, -1, -1, -1],
-    [-1, -1, -1, -1, -1, -1, -1, -1, -1],
-    [-1, -1, -1, -1, -1, -1, -1, -1, -1],
-    [-1, -1, -1, -1, -1, -1, -1, -1, -1],
-    [-1, -1, -1, -1, -1, -1, -1, -1, -1],
-    [-1, -1, -1, -1, -1, -1, -1, -1, -1],
+    [40, 41, 42, 43, 48, 49, 50, 51, -1],
     [-1, -1, -1, -1, -1, -1, -1, -1, -1]
   ],
   colors: lpColors,
@@ -25,7 +25,7 @@ export const LaunchkeyMiniMK3: LaunchkeyMiniMK3Device = {
   },
   command: {
     standalone: [0x9f, 0x0c, 0x00],
-    daw: [0x9f, 0x0c, 0xf7],
+    daw: [0x9f, 0x0c, 0x7f],
     ledOn: [0x99, 'buttonNumber', 'color'],
     ledFlash: [0x9a, 'buttonNumber', 'color'],
     ledPulse: [0x9b, 'buttonNumber', 'color']

--- a/src/utils/MidiDevices/LaunchkeyMiniMK3/LaunchkeyMiniMK3.ts
+++ b/src/utils/MidiDevices/LaunchkeyMiniMK3/LaunchkeyMiniMK3.ts
@@ -3,8 +3,15 @@ import { lpColors, lpCommonColors } from '../LaunchpadX/lpColors'
 
 export const LaunchkeyMiniMK3: LaunchkeyMiniMK3Device = {
   buttonNumbers: [
-    [40, 41, 42, 43, 48, 49, 50, 51],
-    [36, 37, 38, 39, 44, 45, 46, 47],
+    [40, 41, 42, 43, 48, 49, 50, 51, -1],
+    [36, 37, 38, 39, 44, 45, 46, 47, -1],
+    [-1, -1, -1, -1, -1, -1, -1, -1, -1],
+    [-1, -1, -1, -1, -1, -1, -1, -1, -1],
+    [-1, -1, -1, -1, -1, -1, -1, -1, -1],
+    [-1, -1, -1, -1, -1, -1, -1, -1, -1],
+    [-1, -1, -1, -1, -1, -1, -1, -1, -1],
+    [-1, -1, -1, -1, -1, -1, -1, -1, -1],
+    [-1, -1, -1, -1, -1, -1, -1, -1, -1]
   ],
   colors: lpColors,
   commonColors: lpCommonColors,
@@ -21,7 +28,7 @@ export const LaunchkeyMiniMK3: LaunchkeyMiniMK3Device = {
     daw: [0x9f, 0x0c, 0xf7],
     ledOn: [0x99, 'buttonNumber', 'color'],
     ledFlash: [0x9a, 'buttonNumber', 'color'],
-    ledPulse: [0x9b, 'buttonNumber', 'color'],
+    ledPulse: [0x9b, 'buttonNumber', 'color']
   },
   fn: {
     ledOff: (buttonNumber: number) => [0x99, buttonNumber, 0x00],
@@ -48,6 +55,6 @@ export const LaunchkeyMiniMK3: LaunchkeyMiniMK3Device = {
       0x9b,
       buttonNumber,
       typeof color === 'number' ? color : lpColors[color]
-    ],
+    ]
   }
 }

--- a/src/utils/MidiDevices/LaunchpadS/LaunchpadS.ts
+++ b/src/utils/MidiDevices/LaunchpadS/LaunchpadS.ts
@@ -23,6 +23,9 @@ export const LaunchpadS: LaunchpadSDevice = {
     commandType: '90',
     commandColor: '3E'
   },
+  command: {
+    ledOn: [0x90, 'buttonNumber', 'color']
+  },
   fn: {
     ledOff: (buttonNumber: number) => [0x90, buttonNumber, 0x0c],
     ledOn: (buttonNumber: number, color: keyof typeof lpsColors | number) => [

--- a/src/utils/MidiDevices/MidiDevices.ts
+++ b/src/utils/MidiDevices/MidiDevices.ts
@@ -1,6 +1,8 @@
 import { LaunchpadMK2 } from './LaunchpadMK2/LaunchpadMK2'
 import { LaunchpadS } from './LaunchpadS/LaunchpadS'
 import { LaunchpadX } from './LaunchpadX/LaunchpadX'
+import { LaunchkeyMK3 } from './LaunchkeyMK3/LaunchkeyMK3'
+import { LaunchkeyMiniMK3 } from './LaunchkeyMiniMK3/LaunchkeyMiniMK3'
 
 export const Launchpad = {
   X: LaunchpadX,
@@ -8,6 +10,12 @@ export const Launchpad = {
   S: LaunchpadS
 }
 
+export const Launchkey = {
+  MK3: LaunchkeyMK3,
+  MiniMK3: LaunchkeyMiniMK3
+}
+
 export const MidiDevices = {
-  Launchpad
+  Launchpad,
+  Launchkey
 }

--- a/src/utils/MidiDevices/MidiDevices.ts
+++ b/src/utils/MidiDevices/MidiDevices.ts
@@ -7,7 +7,9 @@ import { LaunchkeyMiniMK3 } from './LaunchkeyMiniMK3/LaunchkeyMiniMK3'
 export const Launchpad = {
   X: LaunchpadX,
   MK2: LaunchpadMK2,
-  S: LaunchpadS
+  S: LaunchpadS,
+  MK3: LaunchkeyMK3,
+  MiniMK3: LaunchkeyMiniMK3
 }
 
 export const Launchkey = {
@@ -16,6 +18,5 @@ export const Launchkey = {
 }
 
 export const MidiDevices = {
-  Launchpad,
-  Launchkey
+  Launchpad
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1840,6 +1840,18 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/retry/-/retry-0.4.3.tgz#c2b9d2e374ee62c586d3adbea87199b1d7a7a6ba"
   integrity sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==
 
+"@isaacs/balanced-match@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz#3081dadbc3460661b751e7591d7faea5df39dd29"
+  integrity sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==
+
+"@isaacs/brace-expansion@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz#4b3dabab7d8e75a429414a96bd67bf4c1d13e0f3"
+  integrity sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==
+  dependencies:
+    "@isaacs/balanced-match" "^4.0.1"
+
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-8.0.2.tgz#b37667b7bc181c168782259bab42474fbf52b550"
@@ -7251,7 +7263,7 @@ for-each@^0.3.3, for-each@^0.3.5:
   dependencies:
     is-callable "^1.2.7"
 
-foreground-child@^3.1.0:
+foreground-child@^3.1.0, foreground-child@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-3.3.1.tgz#32e8e9ed1b68a3497befb9ac2b6adf92a638576f"
   integrity sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==
@@ -7533,6 +7545,18 @@ glob@^10.3.10, glob@^10.3.12:
     minipass "^7.1.2"
     package-json-from-dist "^1.0.0"
     path-scurry "^1.11.1"
+
+glob@^11.0.0:
+  version "11.0.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-11.0.3.tgz#9d8087e6d72ddb3c4707b1d2778f80ea3eaefcd6"
+  integrity sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==
+  dependencies:
+    foreground-child "^3.3.1"
+    jackspeak "^4.1.1"
+    minimatch "^10.0.3"
+    minipass "^7.1.2"
+    package-json-from-dist "^1.0.0"
+    path-scurry "^2.0.0"
 
 glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
   version "7.2.3"
@@ -8481,6 +8505,13 @@ jackspeak@^3.1.2:
     "@isaacs/cliui" "^8.0.2"
   optionalDependencies:
     "@pkgjs/parseargs" "^0.11.0"
+
+jackspeak@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/jackspeak/-/jackspeak-4.1.1.tgz#96876030f450502047fc7e8c7fcf8ce8124e43ae"
+  integrity sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==
+  dependencies:
+    "@isaacs/cliui" "^8.0.2"
 
 jake@^10.8.5:
   version "10.9.2"
@@ -9457,6 +9488,11 @@ lru-cache@^10.2.0:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
   integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
 
+lru-cache@^11.0.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-11.1.0.tgz#afafb060607108132dbc1cf8ae661afb69486117"
+  integrity sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==
+
 lru-cache@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
@@ -9676,6 +9712,13 @@ minimatch@^10.0.0:
   integrity sha512-+9TJCIYXgZ2Dm5LxVCFsa8jOm+evMwXHFI0JM1XROmkfkpz8/iLLDh+TwSmyIBrs6C6Xu9294/fq8cBA+P6AqA==
   dependencies:
     brace-expansion "^4.0.1"
+
+minimatch@^10.0.3:
+  version "10.0.3"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.0.3.tgz#cf7a0314a16c4d9ab73a7730a0e8e3c3502d47aa"
+  integrity sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==
+  dependencies:
+    "@isaacs/brace-expansion" "^5.0.0"
 
 minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
@@ -10305,6 +10348,14 @@ path-scurry@^1.11.1:
   dependencies:
     lru-cache "^10.2.0"
     minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
+
+path-scurry@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-2.0.0.tgz#9f052289f23ad8bf9397a2a0425e7b8615c58580"
+  integrity sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==
+  dependencies:
+    lru-cache "^11.0.0"
+    minipass "^7.1.2"
 
 path-to-regexp@0.1.12:
   version "0.1.12"
@@ -11857,6 +11908,14 @@ rimraf@^3.0.0, rimraf@^3.0.2:
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
+
+rimraf@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-6.0.1.tgz#ffb8ad8844dd60332ab15f52bc104bc3ed71ea4e"
+  integrity sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==
+  dependencies:
+    glob "^11.0.0"
+    package-json-from-dist "^1.0.0"
 
 roarr@^2.15.3:
   version "2.15.4"


### PR DESCRIPTION
Added Launchkey MK3 and MiniMK3 support

> [!NOTE]
> Launchkey MK3 hasn't been tested, but should work

Extra changes made:
- Changed from del to rimraf which works on all platforms inside the package.json
- Added commands object to LaunchpadS to fix issues with Typescript
- Fixed the mapping for Launchkey, since it seems to be mapped from bottom to top
- LaunchpadButtonMap now uses lp.command for the live, programmer, daw and standalone modes
- Fixed MidiListener issue where it wouldn't clear/reset/ledOf the pixels when switching modes
- Added Launchkey to the Launchpad devices selection, since cannot get it to work with different names yet

