### PR TITLE
Feat: Front end for sendspin support

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,7 @@ export default function App() {
   const getSystemConfig = useStore((state) => state.getSystemConfig)
   const getSchemas = useStore((state) => state.getSchemas)
   const getClients = useStore((state) => state.getClients)
+  const getInfo = useStore((state) => state.getInfo)
 
   useWindowDimensions()
   useSongDetectorVirtualsAutoApply()
@@ -41,7 +42,8 @@ export default function App() {
     getSystemConfig()
     getSchemas()
     getClients()
-  }, [getVirtuals, getSystemConfig, getSchemas, getClients])
+    getInfo()
+  }, [getVirtuals, getSystemConfig, getSchemas, getClients, getInfo])
 
   useEffect(() => {
     initFrontendConfig()

--- a/src/components/Dialogs/SendspinDialog.tsx
+++ b/src/components/Dialogs/SendspinDialog.tsx
@@ -1,0 +1,389 @@
+import { useState } from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+  Button,
+  TextField,
+  Box,
+  Typography,
+  Chip,
+  CircularProgress,
+  Divider,
+  Tooltip
+} from '@mui/material'
+import {
+  Close,
+  Add,
+  Delete,
+  Edit,
+  Search,
+  CheckCircle,
+  RadioButtonUnchecked,
+  Save,
+  Cancel
+} from '@mui/icons-material'
+import useStore from '../../store/useStore'
+
+interface FormState {
+  id: string
+  server_url: string
+  client_name: string
+}
+
+const emptyForm = (): FormState => ({ id: '', server_url: 'ws://', client_name: 'LedFx' })
+
+const SendspinDialog = () => {
+  const open = useStore((state) => state.dialogs.sendspinManager?.open || false)
+  const setDialogOpenSendspinManager = useStore((state) => state.setDialogOpenSendspinManager)
+  const servers = useStore((state) => state.sendspinServers)
+  const discovered = useStore((state) => state.sendspinDiscovered)
+  const discovering = useStore((state) => state.sendspinDiscovering)
+  const available = useStore((state) => state.sendspinAvailable)
+  const getSendspinServers = useStore((state) => state.getSendspinServers)
+  const addSendspinServer = useStore((state) => state.addSendspinServer)
+  const updateSendspinServer = useStore((state) => state.updateSendspinServer)
+  const deleteSendspinServer = useStore((state) => state.deleteSendspinServer)
+  const renameSendspinServer = useStore((state) => state.renameSendspinServer)
+  const discoverSendspinServers = useStore((state) => state.discoverSendspinServers)
+  const clearSendspinDiscovered = useStore((state) => state.clearSendspinDiscovered)
+
+  const [form, setForm] = useState<FormState>(emptyForm())
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [showForm, setShowForm] = useState(false)
+  const [formError, setFormError] = useState('')
+
+  const handleOpen = () => {
+    getSendspinServers()
+  }
+
+  const handleClose = () => {
+    setDialogOpenSendspinManager(false)
+    setShowForm(false)
+    setEditingId(null)
+    setForm(emptyForm())
+    setFormError('')
+    clearSendspinDiscovered()
+  }
+
+  const startAdd = () => {
+    setEditingId(null)
+    setForm(emptyForm())
+    setFormError('')
+    setShowForm(true)
+  }
+
+  const startEdit = (id: string) => {
+    const s = servers[id]
+    setEditingId(id)
+    setForm({ id, server_url: s.server_url, client_name: s.client_name })
+    setFormError('')
+    setShowForm(true)
+  }
+
+  const cancelForm = () => {
+    setShowForm(false)
+    setEditingId(null)
+    setForm(emptyForm())
+    setFormError('')
+  }
+
+  const validateForm = () => {
+    if (!form.id.trim()) return 'Server ID is required'
+    if (!/^[a-z0-9-_]+$/i.test(form.id.trim()))
+      return 'ID must be a URL-safe slug (letters, numbers, hyphens, underscores)'
+    if (!form.server_url.trim()) return 'Server URL is required'
+    if (!/^wss?:\/\/.+/.test(form.server_url.trim())) return 'URL must start with ws:// or wss://'
+    if (!editingId && servers[form.id.trim()]) return `Server "${form.id.trim()}" already exists`
+    // Renaming: new ID must not already exist (unless it's the same id)
+    if (editingId && form.id.trim() !== editingId && servers[form.id.trim()])
+      return `Server "${form.id.trim()}" already exists`
+    return ''
+  }
+
+  const handleSave = async () => {
+    const err = validateForm()
+    if (err) {
+      setFormError(err)
+      return
+    }
+    setFormError('')
+
+    let ok: boolean
+    if (editingId) {
+      const newId = form.id.trim()
+      const isRename = newId !== editingId
+      if (isRename) {
+        ok = await renameSendspinServer(editingId, newId, {
+          server_url: form.server_url.trim(),
+          client_name: form.client_name.trim() || 'LedFx'
+        })
+      } else {
+        ok = await updateSendspinServer(editingId, {
+          server_url: form.server_url.trim(),
+          client_name: form.client_name.trim() || 'LedFx'
+        })
+      }
+    } else {
+      ok = await addSendspinServer({
+        id: form.id.trim(),
+        server_url: form.server_url.trim(),
+        client_name: form.client_name.trim() || 'LedFx'
+      })
+    }
+    if (ok) {
+      cancelForm()
+      getSendspinServers()
+    }
+  }
+
+  const handleDelete = async (id: string) => {
+    await deleteSendspinServer(id)
+    getSendspinServers()
+  }
+
+  const handleAddDiscovered = async (s: { name: string; server_url: string }) => {
+    const suggestedId = s.name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-|-$/g, '')
+    setEditingId(null)
+    setForm({ id: suggestedId, server_url: s.server_url, client_name: 'LedFx' })
+    setFormError('')
+    setShowForm(true)
+  }
+
+  const serverEntries = Object.entries(servers)
+
+  return (
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      maxWidth="md"
+      fullWidth
+      TransitionProps={{ onEntered: handleOpen }}
+    >
+      <DialogTitle>
+        Sendspin Servers
+        <IconButton
+          aria-label="close"
+          onClick={handleClose}
+          sx={{ position: 'absolute', right: 8, top: 8 }}
+        >
+          <Close />
+        </IconButton>
+      </DialogTitle>
+
+      <DialogContent>
+        {!available && (
+          <Box sx={{ mb: 2 }}>
+            <Chip
+              color="warning"
+              label="Sendspin unavailable — requires Python 3.12+ and aiosendspin package"
+            />
+          </Box>
+        )}
+
+        {/* Configured servers table */}
+        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1 }}>
+          <Typography variant="subtitle1" fontWeight={600}>
+            Configured Servers
+          </Typography>
+          <Box sx={{ display: 'flex', gap: 1 }}>
+            <Button
+              size="small"
+              variant="outlined"
+              startIcon={discovering ? <CircularProgress size={14} /> : <Search />}
+              disabled={discovering || !available}
+              onClick={() => discoverSendspinServers(3.0)}
+            >
+              {discovering ? 'Discovering…' : 'Auto-Discover'}
+            </Button>
+            <Button
+              size="small"
+              variant="contained"
+              startIcon={<Add />}
+              disabled={!available || showForm}
+              onClick={startAdd}
+            >
+              Add Server
+            </Button>
+          </Box>
+        </Box>
+
+        <TableContainer component={Paper} variant="outlined" sx={{ mb: 2 }}>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>ID</TableCell>
+                <TableCell>Server URL</TableCell>
+                <TableCell>Client Name</TableCell>
+                <TableCell align="right">Actions</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {serverEntries.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={4} align="center" sx={{ color: 'text.secondary', py: 3 }}>
+                    No servers configured
+                  </TableCell>
+                </TableRow>
+              ) : (
+                serverEntries.map(([id, s]) => (
+                  <TableRow key={id} hover>
+                    <TableCell>
+                      <Typography variant="body2" fontFamily="monospace">
+                        {id}
+                      </Typography>
+                    </TableCell>
+                    <TableCell>
+                      <Typography
+                        variant="body2"
+                        fontFamily="monospace"
+                        sx={{ wordBreak: 'break-all' }}
+                      >
+                        {s.server_url}
+                      </Typography>
+                    </TableCell>
+                    <TableCell>{s.client_name}</TableCell>
+                    <TableCell align="right">
+                      <Tooltip title="Edit">
+                        <IconButton size="small" onClick={() => startEdit(id)}>
+                          <Edit fontSize="small" />
+                        </IconButton>
+                      </Tooltip>
+                      <Tooltip title="Delete">
+                        <IconButton size="small" color="error" onClick={() => handleDelete(id)}>
+                          <Delete fontSize="small" />
+                        </IconButton>
+                      </Tooltip>
+                    </TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </TableContainer>
+
+        {/* Add / Edit form */}
+        {showForm && (
+          <Box component={Paper} variant="outlined" sx={{ p: 2, mb: 2 }}>
+            <Typography variant="subtitle2" sx={{ mb: 1.5 }}>
+              {editingId ? `Edit "${editingId}"` : 'Add Server'}
+            </Typography>
+            <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+              <TextField
+                label="ID"
+                size="small"
+                value={form.id}
+                onChange={(e) => {
+                  const sanitized = e.target.value
+                    .toLowerCase()
+                    .replace(/\s+/g, '-')
+                    .replace(/[^a-z0-9-_]/g, '')
+                  setForm((f) => ({ ...f, id: sanitized }))
+                }}
+                placeholder="living-room"
+                sx={{ flex: '1 1 140px' }}
+              />
+              <TextField
+                label="Server URL"
+                size="small"
+                value={form.server_url}
+                onChange={(e) => setForm((f) => ({ ...f, server_url: e.target.value }))}
+                placeholder="ws://192.168.1.12:8927/sendspin"
+                sx={{ flex: '3 1 280px' }}
+              />
+              <TextField
+                label="Client Name"
+                size="small"
+                value={form.client_name}
+                onChange={(e) => setForm((f) => ({ ...f, client_name: e.target.value }))}
+                placeholder="LedFx"
+                sx={{ flex: '1 1 120px' }}
+              />
+            </Box>
+            {formError && (
+              <Typography variant="caption" color="error" sx={{ mt: 0.5, display: 'block' }}>
+                {formError}
+              </Typography>
+            )}
+            <Box sx={{ display: 'flex', gap: 1, mt: 1.5, justifyContent: 'flex-end' }}>
+              <Button size="small" startIcon={<Cancel />} onClick={cancelForm}>
+                Cancel
+              </Button>
+              <Button size="small" variant="contained" startIcon={<Save />} onClick={handleSave}>
+                {editingId ? 'Update' : 'Add'}
+              </Button>
+            </Box>
+          </Box>
+        )}
+
+        {/* Discovery results */}
+        {(discovered.length > 0 || discovering) && (
+          <>
+            <Divider sx={{ my: 1 }} />
+            <Typography variant="subtitle1" fontWeight={600} sx={{ mb: 1 }}>
+              Discovered on Network
+            </Typography>
+            <TableContainer component={Paper} variant="outlined">
+              <Table size="small">
+                <TableHead>
+                  <TableRow>
+                    <TableCell>Name</TableCell>
+                    <TableCell>URL</TableCell>
+                    <TableCell>Host</TableCell>
+                    <TableCell align="center">Configured</TableCell>
+                    <TableCell align="right">Action</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {discovered.map((d) => (
+                    <TableRow key={d.server_url} hover>
+                      <TableCell>{d.name}</TableCell>
+                      <TableCell>
+                        <Typography variant="body2" fontFamily="monospace">
+                          {d.server_url}
+                        </Typography>
+                      </TableCell>
+                      <TableCell>
+                        {d.host}:{d.port}
+                      </TableCell>
+                      <TableCell align="center">
+                        {d.already_configured ? (
+                          <CheckCircle fontSize="small" color="success" />
+                        ) : (
+                          <RadioButtonUnchecked fontSize="small" color="disabled" />
+                        )}
+                      </TableCell>
+                      <TableCell align="right">
+                        <Button
+                          size="small"
+                          variant="outlined"
+                          disabled={d.already_configured || showForm}
+                          onClick={() => handleAddDiscovered(d)}
+                        >
+                          Add
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default SendspinDialog

--- a/src/components/SchemaForm/SchemaForm/SchemaForm.tsx
+++ b/src/components/SchemaForm/SchemaForm/SchemaForm.tsx
@@ -14,6 +14,7 @@ import {
 import { Info } from '@mui/icons-material'
 import MicIcon from '@mui/icons-material/Mic'
 import SpeakerIcon from '@mui/icons-material/Speaker'
+import HubIcon from '@mui/icons-material/Hub'
 import BladeBoolean from '../components/Boolean/BladeBoolean'
 import BladeSelect from '../components/String/BladeSelect'
 import BladeSlider from '../components/Number/BladeSlider'
@@ -160,7 +161,9 @@ const SchemaForm = ({
                             value={e}
                             // disabled={group[c][e].indexOf('[Loopback]') > -1}
                           >
-                            {group[c][e].indexOf('[Loopback]') > -1 ? (
+                            {c.toLowerCase() === 'sendspin' ? (
+                              <HubIcon style={{ marginRight: '10px' }} />
+                            ) : group[c][e].indexOf('[Loopback]') > -1 ? (
                               <SpeakerIcon style={{ marginRight: '10px' }} />
                             ) : (
                               <MicIcon style={{ marginRight: '10px' }} />

--- a/src/pages/Pages.tsx
+++ b/src/pages/Pages.tsx
@@ -1,6 +1,7 @@
 import { HashRouter as Router, BrowserRouter, Routes, Route } from 'react-router-dom'
 import FrontendPixelsTooSmall from '../components/Dialogs/FrontendPixelsTooSmall'
 import ClientManagementDialog from '../components/Dialogs/ClientManagementDialog'
+import SendspinDialog from '../components/Dialogs/SendspinDialog'
 import SpotifyLoginRedirect from './Integrations/Spotify/SpotifyLoginRedirect'
 import BackendPlaylistPage from './Scenes/BackendPlaylistPage'
 import useElectronProtocol from '../hooks/useElectronProtocol'
@@ -79,6 +80,7 @@ const Routings = () => {
         {!display && <OneEffect noButton />}
         {!display && <NoHostDialog />}
         {!display && <ClientManagementDialog />}
+        {!display && <SendspinDialog />}
         {!display && isElect && <HostManager />}
         {!display && <FrontendPixelsTooSmall />}
         {!display && <SmartBar open={smartBarOpen} setOpen={setSmartBarOpen} direct={false} />}

--- a/src/pages/Settings/SettingsComponents.tsx
+++ b/src/pages/Settings/SettingsComponents.tsx
@@ -252,7 +252,7 @@ export const SettingsRow = ({
       <div
         style={{
           display: 'flex',
-          color: disabled ? '#000' : '#7b7a7c',
+          color: disabled ? '#000' : 'inherit',
           flexGrow: 1,
           justifyContent: 'flex-end',
           alignItems: 'center',

--- a/src/pages/Settings/Uncategorized.tsx
+++ b/src/pages/Settings/Uncategorized.tsx
@@ -92,15 +92,8 @@ const Uncategorized = () => {
       <SettingsRow alpha title="Log Filtering">
         <LogColorFilterSelect />
       </SettingsRow>
-      <SettingsRow
-        beta
-        title="Sendspin Servers (multi-room audio)"
-      >
-        <Button
-          size="small"
-          variant="outlined"
-          onClick={() => setDialogOpenSendspinManager(true)}
-        >
+      <SettingsRow beta title="Sendspin Servers (HA Music Assistant)">
+        <Button size="small" variant="outlined" onClick={() => setDialogOpenSendspinManager(true)}>
           Manage
         </Button>
       </SettingsRow>

--- a/src/pages/Settings/Uncategorized.tsx
+++ b/src/pages/Settings/Uncategorized.tsx
@@ -3,12 +3,14 @@ import LogColorFilterSelect from './LogFilterSelect'
 import { SettingsRow } from './SettingsComponents'
 // import VisualizerDevWidget from './VisualizerDevWidget'
 import VisualizerDevWidgetYZ from './VisualizerDevWidgetYZ'
+import { Button } from '@mui/material'
 
 const Uncategorized = () => {
   const setFeatures = useStore((state) => state.setFeatures)
   const features = useStore((state) => state.features)
   const blenderAutomagic = useStore((state) => state.uiPersist.blenderAutomagic)
   const setBlenderAutomagic = useStore((state) => state.setBlenderAutomagic)
+  const setDialogOpenSendspinManager = useStore((state) => state.setDialogOpenSendspinManager)
 
   return (
     <>
@@ -89,6 +91,18 @@ const Uncategorized = () => {
       />
       <SettingsRow alpha title="Log Filtering">
         <LogColorFilterSelect />
+      </SettingsRow>
+      <SettingsRow
+        beta
+        title="Sendspin Servers (multi-room audio)"
+      >
+        <Button
+          size="small"
+          variant="outlined"
+          onClick={() => setDialogOpenSendspinManager(true)}
+        >
+          Manage
+        </Button>
       </SettingsRow>
     </>
   )

--- a/src/pages/Settings/Uncategorized.tsx
+++ b/src/pages/Settings/Uncategorized.tsx
@@ -11,6 +11,7 @@ const Uncategorized = () => {
   const blenderAutomagic = useStore((state) => state.uiPersist.blenderAutomagic)
   const setBlenderAutomagic = useStore((state) => state.setBlenderAutomagic)
   const setDialogOpenSendspinManager = useStore((state) => state.setDialogOpenSendspinManager)
+  const backendFeatures = useStore((state) => state.backendFeatures)
 
   return (
     <>
@@ -92,11 +93,17 @@ const Uncategorized = () => {
       <SettingsRow alpha title="Log Filtering">
         <LogColorFilterSelect />
       </SettingsRow>
-      <SettingsRow beta title="Sendspin Servers (HA Music Assistant)">
-        <Button size="small" variant="outlined" onClick={() => setDialogOpenSendspinManager(true)}>
-          Manage
-        </Button>
-      </SettingsRow>
+      {backendFeatures.sendspin && (
+        <SettingsRow beta title="Sendspin Servers (HA Music Assistant)">
+          <Button
+            size="small"
+            variant="outlined"
+            onClick={() => setDialogOpenSendspinManager(true)}
+          >
+            Manage
+          </Button>
+        </SettingsRow>
+      )}
     </>
   )
 }

--- a/src/store/api/storeActions.tsx
+++ b/src/store/api/storeActions.tsx
@@ -132,7 +132,20 @@ const storeActions = (set: any) => ({
       timeout: 0,
       action: 'restart'
     }),
-  getInfo: async () => await Ledfx('/api/info'),
+  backendFeatures: { sendspin: false } as Record<string, boolean>,
+  getInfo: async () => {
+    const resp = await Ledfx('/api/info')
+    if (resp?.features) {
+      set(
+        produce((state: IStore) => {
+          state.backendFeatures = { ...state.backendFeatures, ...resp.features }
+        }),
+        false,
+        'api/gotInfo'
+      )
+    }
+    return resp
+  },
   getUpdateInfo: async (snackbar: boolean) =>
     await Ledfx('/api/check_for_updates', 'GET', {}, snackbar),
   getPing: async (virtId: string) => await Ledfx(`/api/ping/${virtId}`),

--- a/src/store/api/storeConfig.tsx
+++ b/src/store/api/storeConfig.tsx
@@ -72,6 +72,7 @@ export interface ISystemConfig {
   startup_scene_id: string
   lifx_broadcast_address?: string
   lifx_discovery_timeout?: number
+  sendspin_servers?: Record<string, { server_url: string; client_name: string }>
 }
 
 const storeConfig = (set: any) => ({
@@ -111,6 +112,11 @@ const storeConfig = (set: any) => ({
               scenes: undefined
             }
           } as ISystemConfig
+          // Sync sendspin servers from config so the manage dialog always has data
+          if (resp.sendspin_servers && typeof resp.sendspin_servers === 'object') {
+            state.sendspinServers = resp.sendspin_servers
+            state.sendspinAvailable = true
+          }
         }),
         false,
         'api/gotSystemConfig'

--- a/src/store/api/storeSendspin.ts
+++ b/src/store/api/storeSendspin.ts
@@ -1,0 +1,185 @@
+import { produce } from 'immer'
+import { Ledfx } from '../../api/ledfx'
+import type { IStore } from '../useStore'
+import useStore from '../useStore'
+
+const reloadAudioDevices = () => useStore.getState().getAudioDevices()
+
+export interface SendspinServer {
+  server_url: string
+  client_name: string
+}
+
+export interface SendspinServersMap {
+  [id: string]: SendspinServer
+}
+
+export interface SendspinDiscoveredServer {
+  name: string
+  server_url: string
+  host: string
+  port: number
+  already_configured: boolean
+}
+
+const storeSendspin = (set: any) => ({
+  sendspinServers: {} as SendspinServersMap,
+  sendspinDiscovered: [] as SendspinDiscoveredServer[],
+  sendspinDiscovering: false,
+  sendspinAvailable: true,
+
+  getSendspinServers: async () => {
+    const resp = await Ledfx('/api/sendspin/servers', 'GET', undefined, false)
+    if (resp?.status === 'success') {
+      set(
+        produce((state: IStore) => {
+          state.sendspinServers = resp.data?.servers ?? resp.payload?.servers ?? {}
+          state.sendspinAvailable = true
+        }),
+        false,
+        'sendspin/getServers'
+      )
+    } else if (resp?.status === 'failed') {
+      // Endpoint unavailable (Python < 3.12 / missing package) but servers may
+      // still be present in config (synced by getSystemConfig). Keep existing
+      // sendspinServers and just flag the endpoint as unavailable.
+      set(
+        produce((state: IStore) => {
+          state.sendspinAvailable = false
+        }),
+        false,
+        'sendspin/unavailable'
+      )
+    }
+  },
+
+  addSendspinServer: async (data: { id: string; server_url: string; client_name?: string }) => {
+    const resp = await Ledfx('/api/sendspin/servers', 'POST', data)
+    if (resp?.status === 'success') {
+      set(
+        produce((state: IStore) => {
+          state.sendspinServers[data.id] = {
+            server_url: data.server_url,
+            client_name: data.client_name ?? 'LedFx'
+          }
+        }),
+        false,
+        'sendspin/addServer'
+      )
+      reloadAudioDevices()
+      return true
+    }
+    return false
+  },
+
+  updateSendspinServer: async (id: string, data: { server_url?: string; client_name?: string }) => {
+    const resp = await Ledfx(`/api/sendspin/servers/${id}`, 'PUT', data)
+    if (resp?.status === 'success') {
+      set(
+        produce((state: IStore) => {
+          if (state.sendspinServers[id]) {
+            state.sendspinServers[id] = {
+              ...state.sendspinServers[id],
+              ...data
+            }
+          }
+        }),
+        false,
+        'sendspin/updateServer'
+      )
+      reloadAudioDevices()
+      return true
+    }
+    return false
+  },
+
+  deleteSendspinServer: async (id: string) => {
+    const resp = await Ledfx(`/api/sendspin/servers/${id}`, 'DELETE')
+    if (resp?.status === 'success') {
+      set(
+        produce((state: IStore) => {
+          delete state.sendspinServers[id]
+        }),
+        false,
+        'sendspin/deleteServer'
+      )
+      reloadAudioDevices()
+      return true
+    }
+    return false
+  },
+
+  renameSendspinServer: async (
+    oldId: string,
+    newId: string,
+    data: { server_url: string; client_name: string }
+  ) => {
+    // DELETE the old entry first, then POST a new one with the new id
+    const delResp = await Ledfx(`/api/sendspin/servers/${oldId}`, 'DELETE')
+    if (delResp?.status !== 'success') return false
+    const addResp = await Ledfx('/api/sendspin/servers', 'POST', {
+      id: newId,
+      server_url: data.server_url,
+      client_name: data.client_name
+    })
+    if (addResp?.status === 'success') {
+      set(
+        produce((state: IStore) => {
+          delete state.sendspinServers[oldId]
+          state.sendspinServers[newId] = {
+            server_url: data.server_url,
+            client_name: data.client_name
+          }
+        }),
+        false,
+        'sendspin/renameServer'
+      )
+      reloadAudioDevices()
+      return true
+    }
+    return false
+  },
+
+  discoverSendspinServers: async (timeout = 3.0) => {
+    set(
+      produce((state: IStore) => {
+        state.sendspinDiscovering = true
+        state.sendspinDiscovered = []
+      }),
+      false,
+      'sendspin/discoverStart'
+    )
+    const resp = await Ledfx(`/api/sendspin/discover?timeout=${timeout}`, 'GET', undefined, false)
+    if (resp?.status === 'success') {
+      set(
+        produce((state: IStore) => {
+          state.sendspinDiscovered = resp.data?.servers ?? []
+          state.sendspinDiscovering = false
+        }),
+        false,
+        'sendspin/discoverDone'
+      )
+    } else {
+      set(
+        produce((state: IStore) => {
+          state.sendspinDiscovering = false
+        }),
+        false,
+        'sendspin/discoverFailed'
+      )
+    }
+  },
+
+  clearSendspinDiscovered: () => {
+    set(
+      produce((state: IStore) => {
+        state.sendspinDiscovered = []
+        state.sendspinDiscovering = false
+      }),
+      false,
+      'sendspin/clearDiscovered'
+    )
+  }
+})
+
+export default storeSendspin

--- a/src/store/migrate.ts
+++ b/src/store/migrate.ts
@@ -4,7 +4,7 @@ import { produce } from 'immer'
 import { Ledfx } from '../api/ledfx'
 import useStore, { IStore } from './useStore'
 import store from '../app/app/utils/store.mjs'
-export const frontendConfig = 47
+export const frontendConfig = 48
 
 export interface MigrationState {
   [key: string]: any
@@ -495,6 +495,18 @@ export const migrations: Migrations = {
           c.type = 'not-set'
         }
       })
+    }
+  }),
+  // Migration 48: Add sendspin feature flag and dialog state
+  48: produce((draft) => {
+    if (draft.features && typeof draft.features.sendspin === 'undefined') {
+      draft.features.sendspin = false
+    }
+    if (draft.showFeatures && typeof draft.showFeatures.sendspin === 'undefined') {
+      draft.showFeatures.sendspin = false
+    }
+    if (draft.dialogs && !draft.dialogs.sendspinManager) {
+      draft.dialogs.sendspinManager = { open: false }
     }
   })
 }

--- a/src/store/ui/storeDialogs.tsx
+++ b/src/store/ui/storeDialogs.tsx
@@ -68,6 +68,9 @@ const storeDialogs = (set: any) => ({
     },
     clientManagement: {
       open: false
+    },
+    sendspinManager: {
+      open: false
     }
   },
   assistant: {
@@ -221,6 +224,16 @@ const storeDialogs = (set: any) => ({
       }),
       false,
       'api/dialog/ClientManagement'
+    ),
+  setDialogOpenSendspinManager: (open: boolean) =>
+    set(
+      produce((state: IStore) => {
+        state.dialogs.sendspinManager = {
+          open
+        }
+      }),
+      false,
+      'api/dialog/SendspinManager'
     )
 })
 

--- a/src/store/ui/storeFeatures.tsx
+++ b/src/store/ui/storeFeatures.tsx
@@ -44,12 +44,9 @@ export type IFeatures =
   | 'showVisualiserInBottomBar'
   | 'bgvisualiser'
   | 'showVisualisersOnDevicesPage'
+  | 'sendspin'
 
 const storeFeatures = (set: any) => ({
-
-
-
-
   features: {
     dev: false,
     cloud: false,
@@ -92,7 +89,8 @@ const storeFeatures = (set: any) => ({
     firetv: false,
     showVisualiserInBottomBar: false,
     bgvisualiser: false,
-    showVisualisersOnDevicesPage: false
+    showVisualisersOnDevicesPage: false,
+    sendspin: false
   },
   showFeatures: {
     dev: false,
@@ -136,7 +134,8 @@ const storeFeatures = (set: any) => ({
     firetv: false,
     showVisualiserInBottomBar: false,
     bgvisualiser: false,
-    showVisualisersOnDevicesPage: false
+    showVisualisersOnDevicesPage: false,
+    sendspin: false
   },
   setFeatures: (feat: IFeatures, use: boolean): void =>
     set(

--- a/src/store/useStore.ts
+++ b/src/store/useStore.ts
@@ -37,6 +37,7 @@ import storeAssets from './api/storeAssets'
 import storeClientIdentity from './ui/storeClientIdentity'
 import storeClients from './api/storeClients'
 import storeVisualizerConfigOptimistic from './ui-persist/storeVisualizerConfigOptimistic'
+import storeSendspin from './api/storeSendspin'
 
 const useStore = create(
   devtools(
@@ -79,7 +80,8 @@ const useStore = create(
           ...storeClientIdentity(set),
           ...storeClients(set),
           ...storeCloud(set),
-          ...storeVisualizerConfigOptimistic(set)
+          ...storeVisualizerConfigOptimistic(set),
+          ...storeSendspin(set)
         })
       ),
       {


### PR DESCRIPTION
## Sendspin Server Management

Adds UI support for managing [aiosendspin](https://github.com/sendspin/aiosendspin) multi-room audio servers.

### Changes

- **New dialog** (`SendspinDialog`) — manage configured sendspin servers with full CRUD (add, edit, rename, delete) and an auto-discover button that scans the local network for sendspin instances
- **New store slice** (`storeSendspin`) — API actions for all sendspin endpoints (`GET/POST/PUT/DELETE /api/sendspin/servers`, `/api/sendspin/discover`); discovery results are cleared whenever the dialog is closed so each open requires a fresh discover
- **Settings row** — a "Sendspin Servers (multi-room audio)" entry in the Uncategorized settings tab with a **Manage** button to open the dialog
- **Config sync** — `sendspin_servers` from `/api/config` is synced into the store on startup so the dialog is pre-populated without an extra fetch
- **Migration 48** — adds `sendspin` feature flag and `sendspinManager` dialog state for existing persisted stores
- Gracefully handles backends where the sendspin package is unavailable (Python < 3.12 / missing `aiosendspin`) — shows a warning chip and disables destructive actions