### PR TITLE
Feat: add startup playlist

### DIFF
--- a/src/pages/Settings/GeneralCard.tsx
+++ b/src/pages/Settings/GeneralCard.tsx
@@ -32,6 +32,7 @@ const GeneralCard = () => {
   const getSystemConfig = useStore((state) => state.getSystemConfig)
   const setSystemConfig = useStore((state) => state.setSystemConfig)
   const scenes = useStore((state) => state.scenes)
+  const playlists = useStore((state) => state.playlists)
   const setIntro = useStore((state) => state.setIntro)
   const isAndroid = process.env.REACT_APP_LEDFX_ANDROID === 'true'
 
@@ -229,6 +230,23 @@ const GeneralCard = () => {
           {Object.keys(scenes).map((scene) => (
             <MenuItem key={scene} value={scene}>
               {scenes[scene].name}
+            </MenuItem>
+          ))}
+        </Select>
+      </div>
+      <div className={`${classes.settingsRow} step-settings-twelve `} style={{ flexBasis: '100%' }}>
+        <label>Playlist on startup</label>
+        <Select
+          value={settings.startup_playlist_id || ''}
+          disableUnderline
+          onChange={(e) => onSystemSettingsChange('startup_playlist_id', e.target.value)}
+        >
+          <MenuItem key={'none'} value={''}>
+            {'None'}
+          </MenuItem>
+          {Object.keys(playlists).map((playlistId) => (
+            <MenuItem key={playlistId} value={playlistId}>
+              {playlists[playlistId].name}
             </MenuItem>
           ))}
         </Select>

--- a/src/store/api/storeConfig.tsx
+++ b/src/store/api/storeConfig.tsx
@@ -70,6 +70,7 @@ export interface ISystemConfig {
   flush_on_deactivate: boolean
   ui_brightness_boost: number
   startup_scene_id: string
+  startup_playlist_id: string
   lifx_broadcast_address?: string
   lifx_discovery_timeout?: number
   sendspin_servers?: Record<string, { server_url: string; client_name: string }>

--- a/src/store/migrate.ts
+++ b/src/store/migrate.ts
@@ -4,7 +4,7 @@ import { produce } from 'immer'
 import { Ledfx } from '../api/ledfx'
 import useStore, { IStore } from './useStore'
 import store from '../app/app/utils/store.mjs'
-export const frontendConfig = 48
+export const frontendConfig = 49
 
 export interface MigrationState {
   [key: string]: any
@@ -508,5 +508,10 @@ export const migrations: Migrations = {
     if (draft.dialogs && !draft.dialogs.sendspinManager) {
       draft.dialogs.sendspinManager = { open: false }
     }
+  }),
+  // Migration 49: Add startup_playlist_id to config
+  49: produce((draft) => {
+    draft.config = draft.config || {}
+    draft.config.startup_playlist_id = ''
   })
 }


### PR DESCRIPTION
## Add `startup_playlist_id` config support

Mirrors the existing `startup_scene_id` pattern to allow selecting a playlist that the backend will trigger at startup.

### Changes

- **`src/store/api/storeConfig.tsx`** — Added `startup_playlist_id: string` to `ISystemConfig`
- **`src/store/migrate.ts`** — Bumped `frontendConfig` to 49; added migration 49 to initialize `startup_playlist_id` to `''`
- **`src/pages/Settings/GeneralCard.tsx`** — Added "Playlist on startup" dropdown in General settings, populated from the playlists store