### PR TITLE
Fix: truncate long scene and playlist names in cards

### DIFF
--- a/src/pages/Scenes/PlaylistCard.tsx
+++ b/src/pages/Scenes/PlaylistCard.tsx
@@ -124,7 +124,7 @@ const PlaylistCard = ({
             width: '100%'
           }}
         >
-          <Stack direction="row" spacing={1}>
+          <Stack direction="row" spacing={1} sx={{ overflow: 'hidden', minWidth: 0 }}>
             {flow && <BladeIcon name={'PlaylistPlay'} />}
             <Typography className={classes.sceneTitle} variant="h5" component="h2">
               {playlist?.name || playlistId}

--- a/src/pages/Scenes/SceneCard.tsx
+++ b/src/pages/Scenes/SceneCard.tsx
@@ -68,7 +68,7 @@ const SceneCard = ({
           }}
           className="step-scenes-five"
         >
-          <Stack direction="row" spacing={1}>
+          <Stack direction="row" spacing={1} sx={{ overflow: 'hidden', minWidth: 0 }}>
             {flow && <BladeIcon name={'Wallpaper'} />}
             <Typography className={classes.sceneTitle} variant="h5" component="h2">
               {scene.name || sceneId}


### PR DESCRIPTION
## Fix: Scene name overflow hiding menu button

Long scene/playlist names were overflowing and covering the 3-dot menu button, making it inaccessible.

### Changes

- Added `minWidth: 0` and `overflow: 'hidden'` to the name `Stack` container in `SceneCard` and `PlaylistCard`
- This allows the existing `text-overflow: ellipsis` style on `sceneTitle` to work correctly within the flex layout
