### PR TITLE
Feat: Venues system with color-override pad grid

### DIFF
--- a/playwright/tests/venues.spec.ts
+++ b/playwright/tests/venues.spec.ts
@@ -1,0 +1,141 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { test, expect } from './fixtures'
+import { clearDialogs } from './helpers'
+
+/**
+ * @title How to: Use Venues with Color Override Pads
+ * @intro
+ * **Venues** group one or more Virtuals together and expose a grid of **color
+ * override pads**. Tapping a pad tints every virtual in the venue with that
+ * pad's color/gradient — without interrupting the running effect's animation.
+ * Tapping the active pad again clears the override and restores normal
+ * playback.
+ */
+test('Venues: create venue, add virtual, activate and clear color override', async ({
+  page
+}) => {
+  test.setTimeout(90000)
+
+  await page.goto('/#/')
+  await clearDialogs(page)
+
+  const virtualName = 'Venue Test Virtual'
+  const venueName = 'Test Venue'
+
+  /**
+   * @doc
+   * Create a Virtual Device from the **Devices** page FAB so there is something
+   * to add to the venue.
+   */
+  await test.step('1. Create a Virtual Device', async () => {
+    await page.locator('.MuiBottomNavigationAction-root').filter({ hasText: 'Devices' }).click()
+    await page.waitForTimeout(1000)
+
+    await page.locator('.MuiFab-root[aria-label="add"]').click()
+    await page.waitForTimeout(500)
+    await page.getByRole('menuitem', { name: 'Add Virtual' }).click()
+
+    const dialog = page.getByRole('dialog')
+    await dialog.waitFor({ state: 'visible' })
+    const nameInput = dialog.locator('input').first()
+    await nameInput.waitFor({ state: 'visible', timeout: 10000 })
+    await nameInput.fill(virtualName)
+
+    await page.getByRole('button', { name: 'Add & Setup Segments' }).click()
+    await page.waitForTimeout(2000)
+
+    // "Add & Setup Segments" opens the full-screen segment editor — go Back
+    await page.getByRole('button', { name: 'Back' }).click()
+    await page.waitForTimeout(500)
+    await page.screenshot({ path: 'test-results/venues-1-virtual-created.png' })
+  })
+
+  /**
+   * @doc
+   * Navigate to the **Venues** tab in the bottom bar and click **New Venue**.
+   * Give it a name and confirm the default 4×4 override pad grid with
+   * **Create**.
+   */
+  await test.step('2. Create a Venue', async () => {
+    await page.locator('.MuiBottomNavigationAction-root').filter({ hasText: 'Venues' }).click()
+    await page.waitForTimeout(1000)
+
+    await page.getByRole('button', { name: 'New Venue' }).click()
+    const dialog = page.getByRole('dialog')
+    await dialog.waitFor({ state: 'visible' })
+    await dialog.getByLabel('Venue name').fill(venueName)
+    await page.screenshot({ path: 'test-results/venues-2-create-dialog.png' })
+
+    await dialog.getByRole('button', { name: 'Create' }).click()
+    await dialog.waitFor({ state: 'detached', timeout: 10000 })
+
+    await expect(page.getByText(venueName).first()).toBeVisible({ timeout: 10000 })
+    await page.screenshot({ path: 'test-results/venues-3-venue-created.png' })
+  })
+
+  /**
+   * @doc
+   * Click **Enter** on the venue card to open its detail page.
+   */
+  await test.step('3. Enter the Venue', async () => {
+    const venueCard = page.locator('.MuiCard-root').filter({ hasText: venueName }).first()
+    await venueCard.getByRole('button', { name: 'Enter' }).click()
+    await page.waitForURL(/\/venues\//, { timeout: 10000 })
+    await page.waitForTimeout(1000)
+    await page.screenshot({ path: 'test-results/venues-4-venue-view.png' })
+  })
+
+  /**
+   * @doc
+   * Use the **Add virtual to venue** autocomplete to add the Virtual created
+   * in step 1. Once added, it appears both as a removable chip under
+   * "Virtuals in this venue" and with a live preview pixel graph.
+   */
+  await test.step('4. Add the Virtual to the Venue', async () => {
+    const addVirtualInput = page.getByRole('combobox', { name: 'Add virtual to venue' })
+    await addVirtualInput.click()
+    await addVirtualInput.fill(virtualName)
+    await page.getByRole('option', { name: virtualName }).click()
+    await page.waitForTimeout(1000)
+
+    await expect(
+      page.locator('.MuiChip-root').filter({ hasText: virtualName })
+    ).toBeVisible({
+      timeout: 10000
+    })
+    await page.screenshot({ path: 'test-results/venues-5-virtual-added.png' })
+  })
+
+  /**
+   * @doc
+   * Tap the first color override pad. This activates the override: the pad
+   * shows an **ON** badge and an **Override Active** chip appears above the
+   * live preview, confirming the tint was applied without freezing the
+   * running effect's animation.
+   */
+  await test.step('5. Activate a Color Override Pad', async () => {
+    const firstPad = page.getByTestId('color-pad-0')
+    await firstPad.click()
+    await page.waitForTimeout(1000)
+
+    await expect(firstPad.getByText('ON')).toBeVisible({ timeout: 10000 })
+    await expect(page.getByText('Override Active')).toBeVisible({ timeout: 10000 })
+    await page.screenshot({ path: 'test-results/venues-6-override-active.png' })
+  })
+
+  /**
+   * @doc
+   * Tap the same pad again to clear the override. The **ON** badge and the
+   * **Override Active** chip both disappear, confirming normal playback
+   * resumed.
+   */
+  await test.step('6. Clear the Color Override', async () => {
+    const firstPad = page.getByTestId('color-pad-0')
+    await firstPad.click()
+    await page.waitForTimeout(1000)
+
+    await expect(firstPad.getByText('ON')).not.toBeVisible({ timeout: 10000 })
+    await expect(page.getByText('Override Active')).not.toBeVisible({ timeout: 10000 })
+    await page.screenshot({ path: 'test-results/venues-7-override-cleared.png' })
+  })
+})

--- a/playwright/tests/venues.spec.ts
+++ b/playwright/tests/venues.spec.ts
@@ -121,6 +121,7 @@ test('Venues: create venue, add virtual, activate and clear color override', asy
     await expect(firstPad.getByText('ON')).toBeVisible({ timeout: 10000 })
     await expect(page.getByText('Override Active')).toBeVisible({ timeout: 10000 })
     await page.screenshot({ path: 'test-results/venues-6-override-active.png' })
+    await page.screenshot({ path: 'playwright/screenshots/venues-override.png', fullPage: true })
   })
 
   /**

--- a/src/components/Bars/BarBottom.tsx
+++ b/src/components/Bars/BarBottom.tsx
@@ -6,7 +6,8 @@ import {
   Dashboard,
   ElectricalServices,
   QueueMusic,
-  AccountTree
+  AccountTree,
+  MeetingRoom
 } from '@mui/icons-material'
 import { useLocation, Link } from 'react-router-dom'
 import useStore from '../../store/useStore'
@@ -189,6 +190,15 @@ export default function BarBottom() {
           value="/Scenes"
           icon={<BladeIcon name="mdi:image" />}
           style={bottomBarOpen.indexOf('Scenes') > -1 ? { color: theme.palette.primary.main } : {}}
+        />
+
+        <BottomNavigationAction
+          component={Link}
+          to="/venues"
+          label="Venues"
+          value="/venues"
+          icon={<MeetingRoom />}
+          style={bottomBarOpen.indexOf('venues') > -1 ? { color: theme.palette.primary.main } : {}}
         />
 
         {features.showPlaylistInBottomBar &&

--- a/src/components/Bars/BarLeft.tsx
+++ b/src/components/Bars/BarLeft.tsx
@@ -1,6 +1,6 @@
 import { useTheme } from '@mui/material/styles'
 import useMediaQuery from '@mui/material/useMediaQuery'
-import { ChevronLeft, ChevronRight, MeetingRoom } from '@mui/icons-material'
+import { ChevronLeft, ChevronRight } from '@mui/icons-material'
 import {
   ListItem,
   ListItemIcon,
@@ -174,31 +174,6 @@ const LeftBar = () => {
               </ListItem>
             </Link>
           ))}
-      </List>
-      <Divider />
-      <List>
-        <Link style={{ textDecoration: 'none' }} to="/venues">
-          <ListItem
-            sx={
-              pathname === '/venues'
-                ? {
-                    backgroundColor: theme.palette.secondary.main,
-                    boxShadow: theme.shadows[12],
-                    '&:hover,&:focus,&:visited,&': {
-                      backgroundColor: theme.palette.secondary.main,
-                      boxShadow: theme.shadows[12]
-                    },
-                    color: '#fff'
-                  }
-                : {}
-            }
-          >
-            <ListItemIcon>
-              <MeetingRoom />
-            </ListItemIcon>
-            <ListItemText primary="Venues" />
-          </ListItem>
-        </Link>
       </List>
       <Divider />
     </Drawer>

--- a/src/components/Bars/BarLeft.tsx
+++ b/src/components/Bars/BarLeft.tsx
@@ -1,6 +1,6 @@
 import { useTheme } from '@mui/material/styles'
 import useMediaQuery from '@mui/material/useMediaQuery'
-import { ChevronLeft, ChevronRight } from '@mui/icons-material'
+import { ChevronLeft, ChevronRight, MeetingRoom } from '@mui/icons-material'
 import {
   ListItem,
   ListItemIcon,
@@ -174,6 +174,31 @@ const LeftBar = () => {
               </ListItem>
             </Link>
           ))}
+      </List>
+      <Divider />
+      <List>
+        <Link style={{ textDecoration: 'none' }} to="/venues">
+          <ListItem
+            sx={
+              pathname === '/venues'
+                ? {
+                    backgroundColor: theme.palette.secondary.main,
+                    boxShadow: theme.shadows[12],
+                    '&:hover,&:focus,&:visited,&': {
+                      backgroundColor: theme.palette.secondary.main,
+                      boxShadow: theme.shadows[12]
+                    },
+                    color: '#fff'
+                  }
+                : {}
+            }
+          >
+            <ListItemIcon>
+              <MeetingRoom />
+            </ListItemIcon>
+            <ListItemText primary="Venues" />
+          </ListItem>
+        </Link>
       </List>
       <Divider />
     </Drawer>

--- a/src/components/Dialogs/AddExistingSegmentDialog.tsx
+++ b/src/components/Dialogs/AddExistingSegmentDialog.tsx
@@ -75,7 +75,11 @@ function ConfirmationDialogRaw(props: ConfirmationDialogRawProps) {
 
   // Build a flat list of individual selectable segments across all virtuals
   // Each entry: { label, segment: [deviceId, start, end, invert] }
-  const segmentOptions: Array<{ label: string; segment: [string, number, number, boolean]; isDevice: boolean }> = []
+  const segmentOptions: Array<{
+    label: string
+    segment: [string, number, number, boolean]
+    isDevice: boolean
+  }> = []
   for (const vKey of virtualKeys) {
     const virt = virtuals[vKey]
     const segs = virt.segments || []
@@ -112,9 +116,7 @@ function ConfirmationDialogRaw(props: ConfirmationDialogRawProps) {
           <Select value={value} style={{ width: '100%' }} onChange={handleChange}>
             {segmentOptions.map((opt, idx) => (
               <MenuItem value={JSON.stringify(opt.segment)} key={idx}>
-                {!opt.isDevice && (
-                  <SubdirectoryArrowRight color="disabled" sx={{ mr: 1 }} />
-                )}
+                {!opt.isDevice && <SubdirectoryArrowRight color="disabled" sx={{ mr: 1 }} />}
                 {opt.label}
               </MenuItem>
             ))}

--- a/src/components/Dialogs/AddExistingSegmentDialog.tsx
+++ b/src/components/Dialogs/AddExistingSegmentDialog.tsx
@@ -72,14 +72,32 @@ function ConfirmationDialogRaw(props: ConfirmationDialogRawProps) {
       }
     })
     .filter((v) => (showGaps ? v : !v.startsWith('gap-')))
-    .filter((v) => virtuals[v].segments.length === 1)
 
-  const segments = virtualKeys.reduce((acc: any, v) => {
-    acc[virtuals[v].config.name] = virtuals[v].segments.flat()
-    return acc
-  }, {})
+  // Build a flat list of individual selectable segments across all virtuals
+  // Each entry: { label, segment: [deviceId, start, end, invert] }
+  const segmentOptions: Array<{ label: string; segment: [string, number, number, boolean]; isDevice: boolean }> = []
+  for (const vKey of virtualKeys) {
+    const virt = virtuals[vKey]
+    const segs = virt.segments || []
+    if (segs.length === 0) continue
+    const name = virt.config?.name ?? vKey
+    if (segs.length === 1) {
+      segmentOptions.push({
+        label: name,
+        segment: segs[0] as [string, number, number, boolean],
+        isDevice: !!virt.is_device
+      })
+    } else {
+      segs.forEach((seg: any, idx: number) => {
+        segmentOptions.push({
+          label: `${name} — seg ${idx + 1}`,
+          segment: seg as [string, number, number, boolean],
+          isDevice: !!virt.is_device
+        })
+      })
+    }
+  }
 
-  // console.log(segments)
   return (
     <Dialog
       disableEscapeKeyDown
@@ -92,19 +110,14 @@ function ConfirmationDialogRaw(props: ConfirmationDialogRawProps) {
       <DialogContent dividers>
         <BladeFrame full>
           <Select value={value} style={{ width: '100%' }} onChange={handleChange}>
-            {Object.keys(segments).map((v) => {
-              const k = virtualKeys.find((vi) => virtuals[vi].config.name === v)
-              return (
-                <MenuItem value={JSON.stringify({ [v]: segments[v] })} key={v}>
-                  {k && virtuals[k].is_device ? (
-                    ''
-                  ) : (
-                    <SubdirectoryArrowRight color="disabled" sx={{ mr: 1 }} />
-                  )}
-                  {v}
-                </MenuItem>
-              )
-            })}
+            {segmentOptions.map((opt, idx) => (
+              <MenuItem value={JSON.stringify(opt.segment)} key={idx}>
+                {!opt.isDevice && (
+                  <SubdirectoryArrowRight color="disabled" sx={{ mr: 1 }} />
+                )}
+                {opt.label}
+              </MenuItem>
+            ))}
           </Select>
         </BladeFrame>
       </DialogContent>
@@ -138,45 +151,39 @@ function AddExistingSegmentDialog({ virtual, config = {} }: { virtual: any; conf
     if (!newValue) {
       return
     }
-    const [name, segments] = Object.entries(JSON.parse(newValue))[0] as [
-      string,
-      [string, number, number, boolean]
-    ]
-    // console.log(name)
-    // console.log(segments)
-    if (name && segments) {
-      const deviceKey = Object.keys(deviceList).find((d) => deviceList[d].id === segments[0])
-      const device = deviceKey ? deviceList[deviceKey] : undefined
-      // console.log(device)
-      const temp = [...virtual.segments, segments]
-      const test = temp.filter((t) => t.length === 4)
+    // newValue is now a JSON-stringified [deviceId, start, end, invert] segment
+    const segments = JSON.parse(newValue) as [string, number, number, boolean]
+    if (!Array.isArray(segments) || segments.length !== 4) return
+    const deviceKey = Object.keys(deviceList).find((d) => deviceList[d].id === segments[0])
+    const device = deviceKey ? deviceList[deviceKey] : undefined
+    const temp = [...virtual.segments, segments]
+    const test = temp.filter((t: any) => t.length === 4)
 
-      updateSegments(virtual.id, test).then(() => {
-        getVirtuals()
-        if (device && virtual.active === false && virtual.segments.length === 0) {
-          if (
-            device.active_virtuals &&
-            device.active_virtuals[0] &&
-            virtuals &&
-            virtuals[device.active_virtuals[0]] &&
-            virtuals[device.active_virtuals[0]].effect &&
-            virtuals[device.active_virtuals[0]].effect.type
-          ) {
-            setEffect(
-              virtual.id,
-              virtuals[device.active_virtuals[0]].effect.type as string,
-              virtuals[device.active_virtuals[0]].effect.config,
-              true
-            )
-          } else {
-            setEffect(virtual.id, 'rainbow', {}, true)
-          }
+    updateSegments(virtual.id, test).then(() => {
+      getVirtuals()
+      if (device && virtual.active === false && virtual.segments.length === 0) {
+        if (
+          device.active_virtuals &&
+          device.active_virtuals[0] &&
+          virtuals &&
+          virtuals[device.active_virtuals[0]] &&
+          virtuals[device.active_virtuals[0]].effect &&
+          virtuals[device.active_virtuals[0]].effect.type
+        ) {
+          setEffect(
+            virtual.id,
+            virtuals[device.active_virtuals[0]].effect.type as string,
+            virtuals[device.active_virtuals[0]].effect.config,
+            true
+          )
+        } else {
+          setEffect(virtual.id, 'rainbow', {}, true)
         }
-        if (device) {
-          highlightSegment(virtual.id, device.id, segments[1], segments[2], false)
-        }
-      })
-    }
+      }
+      if (device) {
+        highlightSegment(virtual.id, device.id, segments[1], segments[2], false)
+      }
+    })
   }
 
   return (

--- a/src/pages/Pages.tsx
+++ b/src/pages/Pages.tsx
@@ -33,6 +33,7 @@ import Home from './Home/Home'
 import User from './User/User'
 import Lock from './Lock'
 import '../App.css'
+import VenuesPage from './Venues/VenuesPage'
 
 const Routings = () => {
   const isElect = isElectron()
@@ -71,6 +72,7 @@ const Routings = () => {
               <Route path="/playlists" element={<BackendPlaylistPage />} />
               {!guest && <Route path="/integrations" element={<Integrations />} />}
               {!guest && <Route path="/settings" element={<SettingsNew />} />}
+              <Route path="/venues" element={<VenuesPage />} />
 
               <Route path="*" element={!guest ? <Home /> : <Scenes />} />
             </>

--- a/src/pages/Pages.tsx
+++ b/src/pages/Pages.tsx
@@ -34,6 +34,7 @@ import User from './User/User'
 import Lock from './Lock'
 import '../App.css'
 import VenuesPage from './Venues/VenuesPage'
+import VenueViewPage from './Venues/VenueViewPage'
 
 const Routings = () => {
   const isElect = isElectron()
@@ -73,6 +74,7 @@ const Routings = () => {
               {!guest && <Route path="/integrations" element={<Integrations />} />}
               {!guest && <Route path="/settings" element={<SettingsNew />} />}
               <Route path="/venues" element={<VenuesPage />} />
+              <Route path="/venues/:venueId" element={<VenueViewPage />} />
 
               <Route path="*" element={!guest ? <Home /> : <Scenes />} />
             </>

--- a/src/pages/Venues/ColorPadGrid.tsx
+++ b/src/pages/Venues/ColorPadGrid.tsx
@@ -1,0 +1,220 @@
+import { useCallback, useState, useRef } from 'react'
+import { Box, Tooltip, Paper, Dialog, DialogTitle, DialogContent, DialogActions, Button, Typography } from '@mui/material'
+import useStore from '../../store/useStore'
+import type { Venue, ColorPad } from '../../store/api/storeVenues'
+import GradientPicker from '../../components/SchemaForm/components/GradientPicker/GradientPicker'
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/** Return a CSS background string for a pad (solid color or gradient). */
+function padBackground(pad: ColorPad): string {
+  if (pad.gradient) return pad.gradient
+  if (pad.color) return pad.color
+  return '#444'
+}
+
+/** Return true if the color is visually dark (for text contrast). */
+function isDark(cssColor: string): boolean {
+  if (cssColor.startsWith('linear-gradient')) return true
+  try {
+    const c = cssColor.replace('#', '')
+    if (c.length !== 6) return true
+    const r = parseInt(c.slice(0, 2), 16)
+    const g = parseInt(c.slice(2, 4), 16)
+    const b = parseInt(c.slice(4, 6), 16)
+    return (r * 299 + g * 587 + b * 114) / 1000 < 128
+  } catch {
+    return true
+  }
+}
+
+// ─── Pad editor dialog ───────────────────────────────────────────────────────
+
+interface PadEditorProps {
+  open: boolean
+  pad: ColorPad
+  onClose: () => void
+  onSave: (pad: ColorPad) => void
+}
+
+function PadEditorDialog({ open, pad, onClose, onSave }: PadEditorProps) {
+  const [currentColor, setCurrentColor] = useState<string>(pad.gradient ?? pad.color ?? '#ff0000')
+  const colors = useStore((state) => state.colors)
+  const getColors = useStore((state) => state.getColors)
+  const addColor = useStore((state) => state.addColor)
+  const showHex = useStore((state) => state.uiPersist.showHex)
+
+  // Fetch colors on first open
+  const fetchedRef = useRef(false)
+  if (open && !fetchedRef.current) {
+    fetchedRef.current = true
+    if (!colors || Object.keys(colors).length === 0) getColors()
+  }
+
+  const handleColorChange = useCallback((value: string) => {
+    setCurrentColor(value)
+  }, [])
+
+  const handleSave = () => {
+    const isGradient = currentColor.includes('gradient')
+    onSave(isGradient ? { gradient: currentColor } : { color: currentColor })
+    onClose()
+  }
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm">
+      <DialogTitle>Edit Pad Color</DialogTitle>
+      <DialogContent>
+        <GradientPicker
+          pickerBgColor={currentColor}
+          isGradient={currentColor.includes('gradient')}
+          colors={colors}
+          sendColorToVirtuals={handleColorChange}
+          handleAddGradient={(name: string, color: string) => addColor({ [name]: color })}
+          showHex={showHex}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button onClick={handleSave} variant="contained">
+          Apply
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}
+
+// ─── Color Pad Grid ──────────────────────────────────────────────────────────
+
+interface Props {
+  venue: Venue
+}
+
+export default function ColorPadGrid({ venue }: Props) {
+  const activeVenueId = useStore((state) => state.activeVenueId)
+  const activeOverridePadIndex = useStore((state) => state.activeOverridePadIndex)
+  const activateVenueOverride = useStore((state) => state.activateVenueOverride)
+  const clearVenueOverride = useStore((state) => state.clearVenueOverride)
+  const updateVenuePad = useStore((state) => state.updateVenuePad)
+
+  const [editingPadIndex, setEditingPadIndex] = useState<number | null>(null)
+  const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const { rows, cols, pads } = venue.color_pads
+
+  const handlePointerDown = useCallback(
+    (index: number) => {
+      longPressTimer.current = setTimeout(() => {
+        longPressTimer.current = null
+        setEditingPadIndex(index)
+      }, 600)
+    },
+    []
+  )
+
+  const handlePointerUp = useCallback(
+    (index: number) => {
+      if (longPressTimer.current !== null) {
+        clearTimeout(longPressTimer.current)
+        longPressTimer.current = null
+        // Short tap → toggle override
+        if (activeOverridePadIndex === index) {
+          clearVenueOverride(venue.id)
+        } else {
+          activateVenueOverride(venue.id, index)
+        }
+      }
+    },
+    [activeOverridePadIndex, venue.id, activateVenueOverride, clearVenueOverride]
+  )
+
+  const handleContextMenu = useCallback(
+    (e: React.MouseEvent, index: number) => {
+      e.preventDefault()
+      setEditingPadIndex(index)
+    },
+    []
+  )
+
+  const handlePadSave = useCallback(
+    async (pad: ColorPad) => {
+      if (editingPadIndex === null) return
+      await updateVenuePad(venue.id, editingPadIndex, pad)
+    },
+    [editingPadIndex, venue.id, updateVenuePad]
+  )
+
+  return (
+    <>
+      <Box
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: `repeat(${cols}, 1fr)`,
+          gap: 1,
+          maxWidth: cols * 72,
+          mb: 1
+        }}
+      >
+        {pads.map((pad, i) => {
+          const isActive = activeVenueId === venue.id && activeOverridePadIndex === i
+          const bg = padBackground(pad)
+          const textColor = isDark(bg) ? '#fff' : '#000'
+          const row = Math.floor(i / cols) + 1
+          const col = (i % cols) + 1
+          return (
+            <Tooltip
+              key={i}
+              title={`Pad ${row}×${col} — long-press or right-click to edit`}
+              placement="top"
+            >
+              <Paper
+                elevation={isActive ? 8 : 2}
+                onPointerDown={() => handlePointerDown(i)}
+                onPointerUp={() => handlePointerUp(i)}
+                onPointerLeave={() => {
+                  if (longPressTimer.current) {
+                    clearTimeout(longPressTimer.current)
+                    longPressTimer.current = null
+                  }
+                }}
+                onContextMenu={(e) => handleContextMenu(e, i)}
+                sx={{
+                  width: 64,
+                  height: 64,
+                  background: bg,
+                  cursor: 'pointer',
+                  border: isActive ? `3px solid white` : '3px solid transparent',
+                  outline: isActive ? '2px solid rgba(255,255,255,0.5)' : 'none',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  userSelect: 'none',
+                  transition: 'all 0.15s',
+                  '&:hover': { opacity: 0.85 }
+                }}
+              >
+                {isActive && (
+                  <Typography variant="caption" sx={{ color: textColor, fontWeight: 'bold' }}>
+                    ON
+                  </Typography>
+                )}
+              </Paper>
+            </Tooltip>
+          )
+        })}
+      </Box>
+      <Typography variant="caption" color="text.secondary">
+        Tap a pad to activate color override · Tap again to clear · Long-press or right-click to
+        edit color
+      </Typography>
+      {editingPadIndex !== null && (
+        <PadEditorDialog
+          open
+          pad={pads[editingPadIndex]}
+          onClose={() => setEditingPadIndex(null)}
+          onSave={handlePadSave}
+        />
+      )}
+    </>
+  )
+}

--- a/src/pages/Venues/ColorPadGrid.tsx
+++ b/src/pages/Venues/ColorPadGrid.tsx
@@ -44,14 +44,44 @@ function defaultPadColor(padIndex: number, totalPads: number): string {
   const c = (1 - Math.abs(2 * l - 1)) * s
   const x = c * (1 - Math.abs(((h / 60) % 2) - 1))
   const m = l - c / 2
-  let r = 0, g = 0, b = 0
-  if (h < 60) { r = c; g = x; b = 0 }
-  else if (h < 120) { r = x; g = c; b = 0 }
-  else if (h < 180) { r = 0; g = c; b = x }
-  else if (h < 240) { r = 0; g = x; b = c }
-  else if (h < 300) { r = x; g = 0; b = c }
-  else { r = c; g = 0; b = x }
-  return '#' + [r + m, g + m, b + m].map((v) => Math.round(v * 255).toString(16).padStart(2, '0')).join('')
+  let r = 0
+  let g = 0
+  let b = 0
+  if (h < 60) {
+    r = c
+    g = x
+    b = 0
+  } else if (h < 120) {
+    r = x
+    g = c
+    b = 0
+  } else if (h < 180) {
+    r = 0
+    g = c
+    b = x
+  } else if (h < 240) {
+    r = 0
+    g = x
+    b = c
+  } else if (h < 300) {
+    r = x
+    g = 0
+    b = c
+  } else {
+    r = c
+    g = 0
+    b = x
+  }
+  return (
+    '#' +
+    [r + m, g + m, b + m]
+      .map((v) =>
+        Math.round(v * 255)
+          .toString(16)
+          .padStart(2, '0')
+      )
+      .join('')
+  )
 }
 
 /** Build the background sx props for a pad. Gradients require backgroundImage. */
@@ -67,8 +97,8 @@ function padSx(pad: ColorPad, padSize: number, isActive: boolean, isEditMode: bo
     border: isActive
       ? '3px solid white'
       : isEditMode
-      ? '3px dashed rgba(255,255,255,0.4)'
-      : '3px solid transparent',
+        ? '3px dashed rgba(255,255,255,0.4)'
+        : '3px solid transparent',
     outline: isActive ? '2px solid rgba(255,255,255,0.5)' : 'none',
     display: 'flex',
     alignItems: 'center',
@@ -122,10 +152,13 @@ function PadEditorDialog({ open, pad, padIndex, totalPads, onClose, onSave }: Pa
   }, [open, pad, colors, getColors])
 
   const defaultColors: string[] = []
-  if (colors?.gradients?.builtin) defaultColors.push(...Object.values(colors.gradients.builtin) as string[])
-  if (colors?.gradients?.user) defaultColors.push(...Object.values(colors.gradients.user) as string[])
-  if (colors?.colors?.builtin) defaultColors.push(...Object.values(colors.colors.builtin) as string[])
-  if (colors?.colors?.user) defaultColors.push(...Object.values(colors.colors.user) as string[])
+  if (colors?.gradients?.builtin)
+    defaultColors.push(...(Object.values(colors.gradients.builtin) as string[]))
+  if (colors?.gradients?.user)
+    defaultColors.push(...(Object.values(colors.gradients.user) as string[]))
+  if (colors?.colors?.builtin)
+    defaultColors.push(...(Object.values(colors.colors.builtin) as string[]))
+  if (colors?.colors?.user) defaultColors.push(...(Object.values(colors.colors.user) as string[]))
 
   const handleSave = () => {
     const isGradient = currentColor.includes('gradient')
@@ -194,9 +227,15 @@ function PadEditorDialog({ open, pad, padIndex, totalPads, onClose, onSave }: Pa
       <DialogActions sx={{ justifyContent: 'space-between', px: 2 }}>
         {confirmReset ? (
           <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
-            <Typography variant="caption" color="warning.main">Reset to default?</Typography>
-            <Button size="small" color="warning" onClick={handleResetClick}>Confirm</Button>
-            <Button size="small" onClick={() => setConfirmReset(false)}>Cancel</Button>
+            <Typography variant="caption" color="warning.main">
+              Reset to default?
+            </Typography>
+            <Button size="small" color="warning" onClick={handleResetClick}>
+              Confirm
+            </Button>
+            <Button size="small" onClick={() => setConfirmReset(false)}>
+              Cancel
+            </Button>
           </Box>
         ) : (
           <Button size="small" color="inherit" onClick={handleResetClick}>
@@ -247,7 +286,14 @@ export default function ColorPadGrid({ venue, isEditMode }: Props) {
         }
       }
     },
-    [isEditMode, activeOverridePadIndex, activeVenueId, venue.id, activateVenueOverride, clearVenueOverride]
+    [
+      isEditMode,
+      activeOverridePadIndex,
+      activeVenueId,
+      venue.id,
+      activateVenueOverride,
+      clearVenueOverride
+    ]
   )
 
   const handlePadSave = useCallback(
@@ -262,7 +308,9 @@ export default function ColorPadGrid({ venue, isEditMode }: Props) {
     <>
       {/* Size selector */}
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
-        <Typography variant="caption" color="text.secondary">Size:</Typography>
+        <Typography variant="caption" color="text.secondary">
+          Size:
+        </Typography>
         <ToggleButtonGroup
           size="small"
           value={padSizeKey}
@@ -291,18 +339,18 @@ export default function ColorPadGrid({ venue, isEditMode }: Props) {
           const isActive = activeVenueId === venue.id && activeOverridePadIndex === i
           const textColor = isDark(pad) ? '#fff' : '#000'
           return (
-              <Paper
-                key={i}
-                elevation={isActive ? 8 : 2}
-                onClick={() => handleClick(i)}
-                sx={padSx(pad, padSize, isActive, isEditMode)}
-              >
-                {isActive && !isEditMode && (
-                  <Typography variant="caption" sx={{ color: textColor, fontWeight: 'bold' }}>
-                    ON
-                  </Typography>
-                )}
-              </Paper>
+            <Paper
+              key={i}
+              elevation={isActive ? 8 : 2}
+              onClick={() => handleClick(i)}
+              sx={padSx(pad, padSize, isActive, isEditMode)}
+            >
+              {isActive && !isEditMode && (
+                <Typography variant="caption" sx={{ color: textColor, fontWeight: 'bold' }}>
+                  ON
+                </Typography>
+              )}
+            </Paper>
           )
         })}
       </Box>

--- a/src/pages/Venues/ColorPadGrid.tsx
+++ b/src/pages/Venues/ColorPadGrid.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import ReactGPicker from 'react-gcolor-picker'
 import {
   Box,
@@ -24,8 +24,16 @@ type PadSizeKey = keyof typeof PAD_SIZES
 /** Normalize a gradient string to always include an explicit angle. */
 function normalizeGradient(colorStr: string): string {
   if (!colorStr || !colorStr.includes('linear-gradient')) return colorStr
-  if (colorStr.match(/linear-gradient\s*\(\s*\d+deg/)) return colorStr
-  return colorStr.replace(/linear-gradient\s*\(/, 'linear-gradient(90deg, ')
+  // No angle specified — add 90deg (left-to-right)
+  if (!colorStr.match(/linear-gradient\s*\(\s*\d+deg/)) {
+    return colorStr.replace(/linear-gradient\s*\(/, 'linear-gradient(90deg, ')
+  }
+  return colorStr
+}
+
+/** Replace 180deg (ReactGPicker's first-time default) with 90deg. */
+function fixDefaultAngle(colorStr: string): string {
+  return colorStr.replace(/linear-gradient\s*\(\s*180deg/, 'linear-gradient(90deg')
 }
 
 /** Return the auto-palette default hex color for pad i of n (mirrors backend). */
@@ -55,6 +63,7 @@ function padSx(pad: ColorPad, padSize: number, isActive: boolean, isEditMode: bo
     width: padSize,
     height: padSize,
     ...(isGrad ? { backgroundImage: bg, backgroundColor: 'transparent' } : { backgroundColor: bg }),
+    backgroundClip: 'padding-box',
     cursor: 'pointer',
     border: isActive
       ? '3px solid white'
@@ -97,14 +106,18 @@ function PadEditorDialog({ open, pad, padIndex, totalPads, onClose, onSave }: Pa
   const initialColor = normalizeGradient(pad.gradient ?? pad.color ?? '#ff0000')
   const [currentColor, setCurrentColor] = useState<string>(initialColor)
   const [confirmReset, setConfirmReset] = useState(false)
+  // Tracks whether the picker had a gradient value before the most recent onChange
+  const wasGradientRef = useRef(Boolean(pad.gradient))
 
   const colors = useStore((state) => state.colors)
   const getColors = useStore((state) => state.getColors)
 
   useEffect(() => {
     if (open) {
-      setCurrentColor(normalizeGradient(pad.gradient ?? pad.color ?? '#ff0000'))
+      const c = normalizeGradient(pad.gradient ?? pad.color ?? '#ff0000')
+      setCurrentColor(c)
       setConfirmReset(false)
+      wasGradientRef.current = c.includes('gradient')
       if (!colors || Object.keys(colors).length === 0) getColors()
     }
   }, [open, pad, colors, getColors])
@@ -121,9 +134,22 @@ function PadEditorDialog({ open, pad, padIndex, totalPads, onClose, onSave }: Pa
     onClose()
   }
 
+  const handleChange = (c: string) => {
+    let normalized = normalizeGradient(c)
+    const isNowGradient = normalized.includes('gradient')
+    // Fix ReactGPicker's 180deg default only on the first solid→gradient switch
+    if (isNowGradient && !wasGradientRef.current) {
+      normalized = fixDefaultAngle(normalized)
+    }
+    wasGradientRef.current = isNowGradient
+    setCurrentColor(normalized)
+  }
+
   const handleResetClick = () => {
     if (confirmReset) {
-      setCurrentColor(defaultPadColor(padIndex, totalPads))
+      const def = defaultPadColor(padIndex, totalPads)
+      setCurrentColor(def)
+      wasGradientRef.current = false
       setConfirmReset(false)
     } else {
       setConfirmReset(true)
@@ -134,19 +160,37 @@ function PadEditorDialog({ open, pad, padIndex, totalPads, onClose, onSave }: Pa
     <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
       <DialogTitle>Edit Pad Color</DialogTitle>
       <DialogContent sx={{ pt: 1, pb: 0 }}>
-        <ReactGPicker
-          colorBoardHeight={150}
-          debounce
-          debounceMS={200}
-          format="hex"
-          gradient
-          solid
-          showAlpha={false}
-          popupWidth={288}
-          value={currentColor}
-          defaultColors={defaultColors}
-          onChange={(c: string) => setCurrentColor(normalizeGradient(c))}
-        />
+        {/* Override ReactGPicker's hardcoded white backgrounds to match app theme */}
+        <Box
+          sx={(theme) => ({
+            '& .colorpicker, & .popup_tabs, & .popup_tabs-header, & .color-picker-panel': {
+              backgroundColor: `${theme.palette.background.paper} !important`
+            },
+            '& .popup_tabs-header-label': {
+              color: `${theme.palette.text.secondary} !important`
+            },
+            '& .popup_tabs-header-label-active': {
+              color: `${theme.palette.text.primary} !important`,
+              backgroundColor: `${theme.palette.background.paper} !important`
+            },
+            '& .gradient-result': { display: 'none' },
+            '& .input_rgba': { display: 'none' }
+          })}
+        >
+          <ReactGPicker
+            colorBoardHeight={150}
+            debounce
+            debounceMS={200}
+            format="hex"
+            gradient
+            solid
+            showAlpha={false}
+            popupWidth={288}
+            value={currentColor}
+            defaultColors={defaultColors}
+            onChange={handleChange}
+          />
+        </Box>
       </DialogContent>
       <DialogActions sx={{ justifyContent: 'space-between', px: 2 }}>
         {confirmReset ? (

--- a/src/pages/Venues/ColorPadGrid.tsx
+++ b/src/pages/Venues/ColorPadGrid.tsx
@@ -100,7 +100,7 @@ export default function ColorPadGrid({ venue }: Props) {
   const [editingPadIndex, setEditingPadIndex] = useState<number | null>(null)
   const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-  const { rows, cols, pads } = venue.color_pads
+  const { cols, pads } = venue.color_pads
 
   const handlePointerDown = useCallback(
     (index: number) => {

--- a/src/pages/Venues/ColorPadGrid.tsx
+++ b/src/pages/Venues/ColorPadGrid.tsx
@@ -341,6 +341,7 @@ export default function ColorPadGrid({ venue, isEditMode }: Props) {
           return (
             <Paper
               key={i}
+              data-testid={`color-pad-${i}`}
               elevation={isActive ? 8 : 2}
               onClick={() => handleClick(i)}
               sx={padSx(pad, padSize, isActive, isEditMode)}

--- a/src/pages/Venues/ColorPadGrid.tsx
+++ b/src/pages/Venues/ColorPadGrid.tsx
@@ -67,7 +67,7 @@ function PadEditorDialog({ open, pad, onClose, onSave }: PadEditorProps) {
       <DialogContent>
         <GradientPicker
           pickerBgColor={currentColor}
-          isGradient={currentColor.includes('gradient')}
+          isGradient={true}
           colors={colors}
           sendColorToVirtuals={handleColorChange}
           handleAddGradient={(name: string, color: string) => addColor({ [name]: color })}
@@ -88,9 +88,10 @@ function PadEditorDialog({ open, pad, onClose, onSave }: PadEditorProps) {
 
 interface Props {
   venue: Venue
+  isEditMode: boolean
 }
 
-export default function ColorPadGrid({ venue }: Props) {
+export default function ColorPadGrid({ venue, isEditMode }: Props) {
   const activeVenueId = useStore((state) => state.activeVenueId)
   const activeOverridePadIndex = useStore((state) => state.activeOverridePadIndex)
   const activateVenueOverride = useStore((state) => state.activateVenueOverride)
@@ -98,42 +99,22 @@ export default function ColorPadGrid({ venue }: Props) {
   const updateVenuePad = useStore((state) => state.updateVenuePad)
 
   const [editingPadIndex, setEditingPadIndex] = useState<number | null>(null)
-  const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const { cols, pads } = venue.color_pads
 
-  const handlePointerDown = useCallback(
+  const handleClick = useCallback(
     (index: number) => {
-      longPressTimer.current = setTimeout(() => {
-        longPressTimer.current = null
+      if (isEditMode) {
         setEditingPadIndex(index)
-      }, 600)
-    },
-    []
-  )
-
-  const handlePointerUp = useCallback(
-    (index: number) => {
-      if (longPressTimer.current !== null) {
-        clearTimeout(longPressTimer.current)
-        longPressTimer.current = null
-        // Short tap → toggle override
-        if (activeOverridePadIndex === index) {
+      } else {
+        if (activeOverridePadIndex === index && activeVenueId === venue.id) {
           clearVenueOverride(venue.id)
         } else {
           activateVenueOverride(venue.id, index)
         }
       }
     },
-    [activeOverridePadIndex, venue.id, activateVenueOverride, clearVenueOverride]
-  )
-
-  const handleContextMenu = useCallback(
-    (e: React.MouseEvent, index: number) => {
-      e.preventDefault()
-      setEditingPadIndex(index)
-    },
-    []
+    [isEditMode, activeOverridePadIndex, activeVenueId, venue.id, activateVenueOverride, clearVenueOverride]
   )
 
   const handlePadSave = useCallback(
@@ -164,26 +145,22 @@ export default function ColorPadGrid({ venue }: Props) {
           return (
             <Tooltip
               key={i}
-              title={`Pad ${row}×${col} — long-press or right-click to edit`}
+              title={isEditMode ? `Edit pad ${row}×${col}` : `Pad ${row}×${col}`}
               placement="top"
             >
               <Paper
                 elevation={isActive ? 8 : 2}
-                onPointerDown={() => handlePointerDown(i)}
-                onPointerUp={() => handlePointerUp(i)}
-                onPointerLeave={() => {
-                  if (longPressTimer.current) {
-                    clearTimeout(longPressTimer.current)
-                    longPressTimer.current = null
-                  }
-                }}
-                onContextMenu={(e) => handleContextMenu(e, i)}
+                onClick={() => handleClick(i)}
                 sx={{
                   width: 64,
                   height: 64,
                   background: bg,
                   cursor: 'pointer',
-                  border: isActive ? `3px solid white` : '3px solid transparent',
+                  border: isActive
+                    ? '3px solid white'
+                    : isEditMode
+                    ? '3px dashed rgba(255,255,255,0.4)'
+                    : '3px solid transparent',
                   outline: isActive ? '2px solid rgba(255,255,255,0.5)' : 'none',
                   display: 'flex',
                   alignItems: 'center',
@@ -193,7 +170,7 @@ export default function ColorPadGrid({ venue }: Props) {
                   '&:hover': { opacity: 0.85 }
                 }}
               >
-                {isActive && (
+                {isActive && !isEditMode && (
                   <Typography variant="caption" sx={{ color: textColor, fontWeight: 'bold' }}>
                     ON
                   </Typography>
@@ -204,8 +181,9 @@ export default function ColorPadGrid({ venue }: Props) {
         })}
       </Box>
       <Typography variant="caption" color="text.secondary">
-        Tap a pad to activate color override · Tap again to clear · Long-press or right-click to
-        edit color
+        {isEditMode
+          ? 'Click a pad to change its color or gradient'
+          : 'Tap a pad to activate color override · Tap again to clear'}
       </Typography>
       {editingPadIndex !== null && (
         <PadEditorDialog

--- a/src/pages/Venues/ColorPadGrid.tsx
+++ b/src/pages/Venues/ColorPadGrid.tsx
@@ -1,31 +1,85 @@
-import { useCallback, useState, useRef } from 'react'
-import { Box, Tooltip, Paper, Dialog, DialogTitle, DialogContent, DialogActions, Button, Typography } from '@mui/material'
+import { useCallback, useEffect, useState } from 'react'
+import ReactGPicker from 'react-gcolor-picker'
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Paper,
+  ToggleButton,
+  ToggleButtonGroup,
+  Tooltip,
+  Typography
+} from '@mui/material'
 import useStore from '../../store/useStore'
-import type { Venue, ColorPad } from '../../store/api/storeVenues'
-import GradientPicker from '../../components/SchemaForm/components/GradientPicker/GradientPicker'
+import type { ColorPad, Venue } from '../../store/api/storeVenues'
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
-/** Return a CSS background string for a pad (solid color or gradient). */
-function padBackground(pad: ColorPad): string {
-  if (pad.gradient) return pad.gradient
-  if (pad.color) return pad.color
-  return '#444'
+const PAD_SIZES = { S: 40, M: 56, L: 72, XL: 96 } as const
+type PadSizeKey = keyof typeof PAD_SIZES
+
+/** Normalize a gradient string to always include an explicit angle. */
+function normalizeGradient(colorStr: string): string {
+  if (!colorStr || !colorStr.includes('linear-gradient')) return colorStr
+  if (colorStr.match(/linear-gradient\s*\(\s*\d+deg/)) return colorStr
+  return colorStr.replace(/linear-gradient\s*\(/, 'linear-gradient(90deg, ')
 }
 
-/** Return true if the color is visually dark (for text contrast). */
-function isDark(cssColor: string): boolean {
-  if (cssColor.startsWith('linear-gradient')) return true
-  try {
-    const c = cssColor.replace('#', '')
-    if (c.length !== 6) return true
-    const r = parseInt(c.slice(0, 2), 16)
-    const g = parseInt(c.slice(2, 4), 16)
-    const b = parseInt(c.slice(4, 6), 16)
-    return (r * 299 + g * 587 + b * 114) / 1000 < 128
-  } catch {
-    return true
+/** Return the auto-palette default hex color for pad i of n (mirrors backend). */
+function defaultPadColor(padIndex: number, totalPads: number): string {
+  if (totalPads === 0) return '#ff0000'
+  const h = (padIndex / totalPads) * 360
+  const s = 1
+  const l = 0.5
+  const c = (1 - Math.abs(2 * l - 1)) * s
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1))
+  const m = l - c / 2
+  let r = 0, g = 0, b = 0
+  if (h < 60) { r = c; g = x; b = 0 }
+  else if (h < 120) { r = x; g = c; b = 0 }
+  else if (h < 180) { r = 0; g = c; b = x }
+  else if (h < 240) { r = 0; g = x; b = c }
+  else if (h < 300) { r = x; g = 0; b = c }
+  else { r = c; g = 0; b = x }
+  return '#' + [r + m, g + m, b + m].map((v) => Math.round(v * 255).toString(16).padStart(2, '0')).join('')
+}
+
+/** Build the background sx props for a pad. Gradients require backgroundImage. */
+function padSx(pad: ColorPad, padSize: number, isActive: boolean, isEditMode: boolean) {
+  const isGrad = Boolean(pad.gradient)
+  const bg = pad.gradient ?? pad.color ?? '#444'
+  return {
+    width: padSize,
+    height: padSize,
+    ...(isGrad ? { backgroundImage: bg, backgroundColor: 'transparent' } : { backgroundColor: bg }),
+    cursor: 'pointer',
+    border: isActive
+      ? '3px solid white'
+      : isEditMode
+      ? '3px dashed rgba(255,255,255,0.4)'
+      : '3px solid transparent',
+    outline: isActive ? '2px solid rgba(255,255,255,0.5)' : 'none',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    userSelect: 'none',
+    transition: 'all 0.15s',
+    '&:hover': { opacity: 0.85 }
   }
+}
+
+/** Return true if a background color is visually dark (for text contrast). */
+function isDark(pad: ColorPad): boolean {
+  if (pad.gradient) return true
+  const c = (pad.color ?? '#000').replace('#', '')
+  if (c.length !== 6) return true
+  const r = parseInt(c.slice(0, 2), 16)
+  const g = parseInt(c.slice(2, 4), 16)
+  const b = parseInt(c.slice(4, 6), 16)
+  return (r * 299 + g * 587 + b * 114) / 1000 < 128
 }
 
 // ─── Pad editor dialog ───────────────────────────────────────────────────────
@@ -33,27 +87,33 @@ function isDark(cssColor: string): boolean {
 interface PadEditorProps {
   open: boolean
   pad: ColorPad
+  padIndex: number
+  totalPads: number
   onClose: () => void
   onSave: (pad: ColorPad) => void
 }
 
-function PadEditorDialog({ open, pad, onClose, onSave }: PadEditorProps) {
-  const [currentColor, setCurrentColor] = useState<string>(pad.gradient ?? pad.color ?? '#ff0000')
+function PadEditorDialog({ open, pad, padIndex, totalPads, onClose, onSave }: PadEditorProps) {
+  const initialColor = normalizeGradient(pad.gradient ?? pad.color ?? '#ff0000')
+  const [currentColor, setCurrentColor] = useState<string>(initialColor)
+  const [confirmReset, setConfirmReset] = useState(false)
+
   const colors = useStore((state) => state.colors)
   const getColors = useStore((state) => state.getColors)
-  const addColor = useStore((state) => state.addColor)
-  const showHex = useStore((state) => state.uiPersist.showHex)
 
-  // Fetch colors on first open
-  const fetchedRef = useRef(false)
-  if (open && !fetchedRef.current) {
-    fetchedRef.current = true
-    if (!colors || Object.keys(colors).length === 0) getColors()
-  }
+  useEffect(() => {
+    if (open) {
+      setCurrentColor(normalizeGradient(pad.gradient ?? pad.color ?? '#ff0000'))
+      setConfirmReset(false)
+      if (!colors || Object.keys(colors).length === 0) getColors()
+    }
+  }, [open, pad, colors, getColors])
 
-  const handleColorChange = useCallback((value: string) => {
-    setCurrentColor(value)
-  }, [])
+  const defaultColors: string[] = []
+  if (colors?.gradients?.builtin) defaultColors.push(...Object.values(colors.gradients.builtin) as string[])
+  if (colors?.gradients?.user) defaultColors.push(...Object.values(colors.gradients.user) as string[])
+  if (colors?.colors?.builtin) defaultColors.push(...Object.values(colors.colors.builtin) as string[])
+  if (colors?.colors?.user) defaultColors.push(...Object.values(colors.colors.user) as string[])
 
   const handleSave = () => {
     const isGradient = currentColor.includes('gradient')
@@ -61,24 +121,51 @@ function PadEditorDialog({ open, pad, onClose, onSave }: PadEditorProps) {
     onClose()
   }
 
+  const handleResetClick = () => {
+    if (confirmReset) {
+      setCurrentColor(defaultPadColor(padIndex, totalPads))
+      setConfirmReset(false)
+    } else {
+      setConfirmReset(true)
+    }
+  }
+
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="sm">
+    <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
       <DialogTitle>Edit Pad Color</DialogTitle>
-      <DialogContent>
-        <GradientPicker
-          pickerBgColor={currentColor}
-          isGradient={true}
-          colors={colors}
-          sendColorToVirtuals={handleColorChange}
-          handleAddGradient={(name: string, color: string) => addColor({ [name]: color })}
-          showHex={showHex}
+      <DialogContent sx={{ pt: 1, pb: 0 }}>
+        <ReactGPicker
+          colorBoardHeight={150}
+          debounce
+          debounceMS={200}
+          format="hex"
+          gradient
+          solid
+          showAlpha={false}
+          popupWidth={288}
+          value={currentColor}
+          defaultColors={defaultColors}
+          onChange={(c: string) => setCurrentColor(normalizeGradient(c))}
         />
       </DialogContent>
-      <DialogActions>
-        <Button onClick={onClose}>Cancel</Button>
-        <Button onClick={handleSave} variant="contained">
-          Apply
-        </Button>
+      <DialogActions sx={{ justifyContent: 'space-between', px: 2 }}>
+        {confirmReset ? (
+          <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+            <Typography variant="caption" color="warning.main">Reset to default?</Typography>
+            <Button size="small" color="warning" onClick={handleResetClick}>Confirm</Button>
+            <Button size="small" onClick={() => setConfirmReset(false)}>Cancel</Button>
+          </Box>
+        ) : (
+          <Button size="small" color="inherit" onClick={handleResetClick}>
+            Reset to Default
+          </Button>
+        )}
+        <Box sx={{ display: 'flex', gap: 1 }}>
+          <Button onClick={onClose}>Cancel</Button>
+          <Button onClick={handleSave} variant="contained">
+            Apply
+          </Button>
+        </Box>
       </DialogActions>
     </Dialog>
   )
@@ -99,8 +186,11 @@ export default function ColorPadGrid({ venue, isEditMode }: Props) {
   const updateVenuePad = useStore((state) => state.updateVenuePad)
 
   const [editingPadIndex, setEditingPadIndex] = useState<number | null>(null)
+  const [padSizeKey, setPadSizeKey] = useState<PadSizeKey>('M')
+  const padSize = PAD_SIZES[padSizeKey]
 
   const { cols, pads } = venue.color_pads
+  const gap = 8
 
   const handleClick = useCallback(
     (index: number) => {
@@ -127,19 +217,36 @@ export default function ColorPadGrid({ venue, isEditMode }: Props) {
 
   return (
     <>
+      {/* Size selector */}
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+        <Typography variant="caption" color="text.secondary">Size:</Typography>
+        <ToggleButtonGroup
+          size="small"
+          value={padSizeKey}
+          exclusive
+          onChange={(_, v) => v && setPadSizeKey(v as PadSizeKey)}
+        >
+          {(Object.keys(PAD_SIZES) as PadSizeKey[]).map((k) => (
+            <ToggleButton key={k} value={k} sx={{ px: 1, py: 0.25, fontSize: '0.7rem' }}>
+              {k}
+            </ToggleButton>
+          ))}
+        </ToggleButtonGroup>
+      </Box>
+
+      {/* Pad grid */}
       <Box
         sx={{
           display: 'grid',
-          gridTemplateColumns: `repeat(${cols}, 1fr)`,
-          gap: 1,
-          maxWidth: cols * 72,
-          mb: 1
+          gridTemplateColumns: `repeat(${cols}, ${padSize}px)`,
+          gap: `${gap}px`,
+          mb: 1,
+          width: 'fit-content'
         }}
       >
         {pads.map((pad, i) => {
           const isActive = activeVenueId === venue.id && activeOverridePadIndex === i
-          const bg = padBackground(pad)
-          const textColor = isDark(bg) ? '#fff' : '#000'
+          const textColor = isDark(pad) ? '#fff' : '#000'
           const row = Math.floor(i / cols) + 1
           const col = (i % cols) + 1
           return (
@@ -151,24 +258,7 @@ export default function ColorPadGrid({ venue, isEditMode }: Props) {
               <Paper
                 elevation={isActive ? 8 : 2}
                 onClick={() => handleClick(i)}
-                sx={{
-                  width: 64,
-                  height: 64,
-                  background: bg,
-                  cursor: 'pointer',
-                  border: isActive
-                    ? '3px solid white'
-                    : isEditMode
-                    ? '3px dashed rgba(255,255,255,0.4)'
-                    : '3px solid transparent',
-                  outline: isActive ? '2px solid rgba(255,255,255,0.5)' : 'none',
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  userSelect: 'none',
-                  transition: 'all 0.15s',
-                  '&:hover': { opacity: 0.85 }
-                }}
+                sx={padSx(pad, padSize, isActive, isEditMode)}
               >
                 {isActive && !isEditMode && (
                   <Typography variant="caption" sx={{ color: textColor, fontWeight: 'bold' }}>
@@ -180,15 +270,19 @@ export default function ColorPadGrid({ venue, isEditMode }: Props) {
           )
         })}
       </Box>
+
       <Typography variant="caption" color="text.secondary">
         {isEditMode
           ? 'Click a pad to change its color or gradient'
           : 'Tap a pad to activate color override · Tap again to clear'}
       </Typography>
+
       {editingPadIndex !== null && (
         <PadEditorDialog
           open
           pad={pads[editingPadIndex]}
+          padIndex={editingPadIndex}
+          totalPads={pads.length}
           onClose={() => setEditingPadIndex(null)}
           onSave={handlePadSave}
         />

--- a/src/pages/Venues/ColorPadGrid.tsx
+++ b/src/pages/Venues/ColorPadGrid.tsx
@@ -10,7 +10,6 @@ import {
   Paper,
   ToggleButton,
   ToggleButtonGroup,
-  Tooltip,
   Typography
 } from '@mui/material'
 import useStore from '../../store/useStore'
@@ -230,7 +229,7 @@ export default function ColorPadGrid({ venue, isEditMode }: Props) {
   const updateVenuePad = useStore((state) => state.updateVenuePad)
 
   const [editingPadIndex, setEditingPadIndex] = useState<number | null>(null)
-  const [padSizeKey, setPadSizeKey] = useState<PadSizeKey>('M')
+  const [padSizeKey, setPadSizeKey] = useState<PadSizeKey>('XL')
   const padSize = PAD_SIZES[padSizeKey]
 
   const { cols, pads } = venue.color_pads
@@ -291,15 +290,9 @@ export default function ColorPadGrid({ venue, isEditMode }: Props) {
         {pads.map((pad, i) => {
           const isActive = activeVenueId === venue.id && activeOverridePadIndex === i
           const textColor = isDark(pad) ? '#fff' : '#000'
-          const row = Math.floor(i / cols) + 1
-          const col = (i % cols) + 1
           return (
-            <Tooltip
-              key={i}
-              title={isEditMode ? `Edit pad ${row}×${col}` : `Pad ${row}×${col}`}
-              placement="top"
-            >
               <Paper
+                key={i}
                 elevation={isActive ? 8 : 2}
                 onClick={() => handleClick(i)}
                 sx={padSx(pad, padSize, isActive, isEditMode)}
@@ -310,7 +303,6 @@ export default function ColorPadGrid({ venue, isEditMode }: Props) {
                   </Typography>
                 )}
               </Paper>
-            </Tooltip>
           )
         })}
       </Box>

--- a/src/pages/Venues/VenueView.tsx
+++ b/src/pages/Venues/VenueView.tsx
@@ -1,13 +1,5 @@
 import { useCallback, useState } from 'react'
-import {
-  Box,
-  Button,
-  Chip,
-  Typography,
-  Divider,
-  Autocomplete,
-  TextField
-} from '@mui/material'
+import { Box, Button, Chip, Typography, Divider, Autocomplete, TextField } from '@mui/material'
 import { ArrowBack } from '@mui/icons-material'
 import useStore from '../../store/useStore'
 import type { Venue } from '../../store/api/storeVenues'
@@ -53,9 +45,7 @@ export default function VenueView({ venue, onLeave }: Props) {
     [venue.id, removeVirtualFromVenue]
   )
 
-  const memberVirtuals = venue.virtual_ids
-    .map((id) => virtuals[id])
-    .filter(Boolean)
+  const memberVirtuals = venue.virtual_ids.map((id) => virtuals[id]).filter(Boolean)
 
   const notYetAdded = availableVirtuals.filter((v) => !venue.virtual_ids.includes(v.id))
 

--- a/src/pages/Venues/VenueView.tsx
+++ b/src/pages/Venues/VenueView.tsx
@@ -75,7 +75,7 @@ export default function VenueView({ venue, onLeave }: Props) {
       <Typography variant="subtitle1" gutterBottom>
         Color Override Pads
       </Typography>
-      <ColorPadGrid venue={venue} />
+      <ColorPadGrid venue={venue} isEditMode={false} />
 
       <Divider sx={{ my: 3 }} />
 

--- a/src/pages/Venues/VenueView.tsx
+++ b/src/pages/Venues/VenueView.tsx
@@ -1,0 +1,113 @@
+import { useCallback, useState } from 'react'
+import {
+  Box,
+  Button,
+  Chip,
+  Typography,
+  Divider,
+  Autocomplete,
+  TextField
+} from '@mui/material'
+import { ArrowBack } from '@mui/icons-material'
+import useStore from '../../store/useStore'
+import type { Venue } from '../../store/api/storeVenues'
+import ColorPadGrid from './ColorPadGrid'
+
+interface Props {
+  venue: Venue
+  onLeave: () => void
+}
+
+export default function VenueView({ venue, onLeave }: Props) {
+  const virtuals = useStore((state) => state.virtuals)
+  const venues = useStore((state) => state.venues)
+  const addVirtualToVenue = useStore((state) => state.addVirtualToVenue)
+  const removeVirtualFromVenue = useStore((state) => state.removeVirtualFromVenue)
+  const [adding, setAdding] = useState(false)
+
+  // Compute which virtual IDs are already in ANY venue (for greying-out in picker)
+  const occupiedVirtualIds = Object.values(venues).reduce<Set<string>>((acc, v) => {
+    for (const vid of v.virtual_ids) acc.add(vid)
+    return acc
+  }, new Set())
+
+  // Virtual options for autocomplete: exclude those already in another venue
+  const availableVirtuals = Object.values(virtuals).filter(
+    (v) => !occupiedVirtualIds.has(v.id) || venue.virtual_ids.includes(v.id)
+  )
+
+  const handleAddVirtual = useCallback(
+    async (_: any, newValue: any) => {
+      if (!newValue) return
+      setAdding(true)
+      await addVirtualToVenue(venue.id, newValue.id)
+      setAdding(false)
+    },
+    [venue.id, addVirtualToVenue]
+  )
+
+  const handleRemoveVirtual = useCallback(
+    async (virtualId: string) => {
+      await removeVirtualFromVenue(venue.id, virtualId)
+    },
+    [venue.id, removeVirtualFromVenue]
+  )
+
+  const memberVirtuals = venue.virtual_ids
+    .map((id) => virtuals[id])
+    .filter(Boolean)
+
+  const notYetAdded = availableVirtuals.filter((v) => !venue.virtual_ids.includes(v.id))
+
+  return (
+    <Box sx={{ p: 2 }}>
+      {/* Header */}
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 2 }}>
+        <Button startIcon={<ArrowBack />} onClick={onLeave} variant="outlined" size="small">
+          All Venues
+        </Button>
+        <Typography variant="h5">{venue.name}</Typography>
+      </Box>
+
+      <Divider sx={{ mb: 2 }} />
+
+      {/* Color Override Pad Grid */}
+      <Typography variant="subtitle1" gutterBottom>
+        Color Override Pads
+      </Typography>
+      <ColorPadGrid venue={venue} />
+
+      <Divider sx={{ my: 3 }} />
+
+      {/* Virtual membership */}
+      <Typography variant="subtitle1" gutterBottom>
+        Virtuals in this venue
+      </Typography>
+      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mb: 2 }}>
+        {memberVirtuals.length === 0 && (
+          <Typography color="text.secondary" variant="body2">
+            No virtuals assigned yet.
+          </Typography>
+        )}
+        {memberVirtuals.map((v) => (
+          <Chip
+            key={v.id}
+            label={v.config?.name ?? v.id}
+            onDelete={() => handleRemoveVirtual(v.id)}
+          />
+        ))}
+      </Box>
+      <Autocomplete
+        options={notYetAdded}
+        getOptionLabel={(v) => v.config?.name ?? v.id}
+        onChange={handleAddVirtual}
+        value={null}
+        disabled={adding}
+        renderInput={(params) => (
+          <TextField {...params} label="Add virtual to venue" size="small" sx={{ maxWidth: 320 }} />
+        )}
+        isOptionEqualToValue={(a, b) => a.id === b.id}
+      />
+    </Box>
+  )
+}

--- a/src/pages/Venues/VenueViewPage.tsx
+++ b/src/pages/Venues/VenueViewPage.tsx
@@ -47,6 +47,7 @@ export default function VenueViewPage() {
     return () => {
       setPixelGraphs([])
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only re-subscribe when virtual_ids actually change
   }, [venue?.virtual_ids, setPixelGraphs])
 
   const handleBack = useCallback(async () => {
@@ -155,9 +156,20 @@ export default function VenueViewPage() {
                     {v.config?.name ?? v.id}
                   </Typography>
                   {effectName ? (
-                    <Chip label={effectName} size="small" variant="outlined" sx={{ height: 18, fontSize: '0.65rem' }} />
+                    <Chip
+                      label={effectName}
+                      size="small"
+                      variant="outlined"
+                      sx={{ height: 18, fontSize: '0.65rem' }}
+                    />
                   ) : (
-                    <Chip label="No effect" size="small" variant="outlined" color="default" sx={{ height: 18, fontSize: '0.65rem', opacity: 0.5 }} />
+                    <Chip
+                      label="No effect"
+                      size="small"
+                      variant="outlined"
+                      color="default"
+                      sx={{ height: 18, fontSize: '0.65rem', opacity: 0.5 }}
+                    />
                   )}
                 </Box>
                 <PixelGraph virtId={v.id} active={v.active} db />

--- a/src/pages/Venues/VenueViewPage.tsx
+++ b/src/pages/Venues/VenueViewPage.tsx
@@ -11,9 +11,10 @@ import {
   CircularProgress,
   ToggleButton
 } from '@mui/material'
-import { ArrowBack, Edit, EditOff } from '@mui/icons-material'
+import { ArrowBack, Edit, EditOff, FlashOn } from '@mui/icons-material'
 import useStore from '../../store/useStore'
 import ColorPadGrid from './ColorPadGrid'
+import PixelGraph from '../../components/PixelGraph/PixelGraph'
 
 export default function VenueViewPage() {
   const { venueId } = useParams<{ venueId: string }>()
@@ -26,6 +27,9 @@ export default function VenueViewPage() {
   const addVirtualToVenue = useStore((state) => state.addVirtualToVenue)
   const removeVirtualFromVenue = useStore((state) => state.removeVirtualFromVenue)
   const clearVenueOverride = useStore((state) => state.clearVenueOverride)
+  const setPixelGraphs = useStore((state) => state.setPixelGraphs)
+  const activeVenueId = useStore((state) => state.activeVenueId)
+  const activeOverridePadIndex = useStore((state) => state.activeOverridePadIndex)
 
   const [adding, setAdding] = useState(false)
   const [isEditMode, setIsEditMode] = useState(false)
@@ -35,6 +39,15 @@ export default function VenueViewPage() {
       getVenues()
     }
   }, [venue, getVenues])
+
+  // Subscribe to WebSocket pixel updates for all venue virtuals
+  useEffect(() => {
+    if (!venue) return
+    setPixelGraphs(venue.virtual_ids)
+    return () => {
+      setPixelGraphs([])
+    }
+  }, [venue?.virtual_ids, setPixelGraphs])
 
   const handleBack = useCallback(async () => {
     if (venueId) await clearVenueOverride(venueId)
@@ -67,6 +80,8 @@ export default function VenueViewPage() {
       </Box>
     )
   }
+
+  const overrideActive = activeVenueId === venueId && activeOverridePadIndex !== null
 
   const occupiedVirtualIds = Object.values(venues).reduce<Set<string>>((acc, v) => {
     for (const vid of v.virtual_ids) acc.add(vid)
@@ -109,6 +124,48 @@ export default function VenueViewPage() {
         </ToggleButton>
       </Box>
       <ColorPadGrid venue={venue} isEditMode={isEditMode} />
+
+      <Divider sx={{ my: 3 }} />
+
+      {/* Live Preview */}
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+        <Typography variant="subtitle1">Live Preview</Typography>
+        {overrideActive && (
+          <Chip
+            icon={<FlashOn fontSize="small" />}
+            label="Override Active"
+            size="small"
+            color="warning"
+            variant="outlined"
+          />
+        )}
+      </Box>
+      {memberVirtuals.length === 0 ? (
+        <Typography color="text.secondary" variant="body2" sx={{ mb: 1 }}>
+          Add virtuals to see a live preview.
+        </Typography>
+      ) : (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, mb: 1 }}>
+          {memberVirtuals.map((v) => {
+            const effectName = v.effect?.name ?? v.effect?.type ?? null
+            return (
+              <Box key={v.id}>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5 }}>
+                  <Typography variant="caption" color="text.secondary">
+                    {v.config?.name ?? v.id}
+                  </Typography>
+                  {effectName ? (
+                    <Chip label={effectName} size="small" variant="outlined" sx={{ height: 18, fontSize: '0.65rem' }} />
+                  ) : (
+                    <Chip label="No effect" size="small" variant="outlined" color="default" sx={{ height: 18, fontSize: '0.65rem', opacity: 0.5 }} />
+                  )}
+                </Box>
+                <PixelGraph virtId={v.id} active={v.active} db />
+              </Box>
+            )
+          })}
+        </Box>
+      )}
 
       <Divider sx={{ my: 3 }} />
 

--- a/src/pages/Venues/VenueViewPage.tsx
+++ b/src/pages/Venues/VenueViewPage.tsx
@@ -1,0 +1,146 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
+import {
+  Box,
+  Button,
+  Chip,
+  Typography,
+  Divider,
+  Autocomplete,
+  TextField,
+  CircularProgress,
+  ToggleButton
+} from '@mui/material'
+import { ArrowBack, Edit, EditOff } from '@mui/icons-material'
+import useStore from '../../store/useStore'
+import ColorPadGrid from './ColorPadGrid'
+
+export default function VenueViewPage() {
+  const { venueId } = useParams<{ venueId: string }>()
+  const navigate = useNavigate()
+
+  const venue = useStore((state) => (venueId ? state.venues[venueId] : undefined))
+  const virtuals = useStore((state) => state.virtuals)
+  const venues = useStore((state) => state.venues)
+  const getVenues = useStore((state) => state.getVenues)
+  const addVirtualToVenue = useStore((state) => state.addVirtualToVenue)
+  const removeVirtualFromVenue = useStore((state) => state.removeVirtualFromVenue)
+  const clearVenueOverride = useStore((state) => state.clearVenueOverride)
+
+  const [adding, setAdding] = useState(false)
+  const [isEditMode, setIsEditMode] = useState(false)
+
+  useEffect(() => {
+    if (!venue) {
+      getVenues()
+    }
+  }, [venue, getVenues])
+
+  const handleBack = useCallback(async () => {
+    if (venueId) await clearVenueOverride(venueId)
+    navigate('/venues')
+  }, [venueId, clearVenueOverride, navigate])
+
+  const handleAddVirtual = useCallback(
+    async (_: any, newValue: any) => {
+      if (!newValue || !venueId) return
+      setAdding(true)
+      await addVirtualToVenue(venueId, newValue.id)
+      setAdding(false)
+    },
+    [venueId, addVirtualToVenue]
+  )
+
+  const handleRemoveVirtual = useCallback(
+    async (virtualId: string) => {
+      if (!venueId) return
+      await removeVirtualFromVenue(venueId, virtualId)
+    },
+    [venueId, removeVirtualFromVenue]
+  )
+
+  if (!venue) {
+    return (
+      <Box sx={{ p: 2, display: 'flex', alignItems: 'center', gap: 2 }}>
+        <CircularProgress size={20} />
+        <Typography>Loading venue…</Typography>
+      </Box>
+    )
+  }
+
+  const occupiedVirtualIds = Object.values(venues).reduce<Set<string>>((acc, v) => {
+    for (const vid of v.virtual_ids) acc.add(vid)
+    return acc
+  }, new Set())
+
+  const availableVirtuals = Object.values(virtuals).filter(
+    (v) => !occupiedVirtualIds.has(v.id) || venue.virtual_ids.includes(v.id)
+  )
+
+  const memberVirtuals = venue.virtual_ids.map((id) => virtuals[id]).filter(Boolean)
+  const notYetAdded = availableVirtuals.filter((v) => !venue.virtual_ids.includes(v.id))
+
+  return (
+    <Box sx={{ p: 2 }}>
+      {/* Header */}
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 2 }}>
+        <Button startIcon={<ArrowBack />} onClick={handleBack} variant="outlined" size="small">
+          All Venues
+        </Button>
+        <Typography variant="h5">{venue.name}</Typography>
+      </Box>
+
+      <Divider sx={{ mb: 2 }} />
+
+      {/* Color Override Pad Grid */}
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 1 }}>
+        <Typography variant="subtitle1">Color Override Pads</Typography>
+        <ToggleButton
+          value="edit"
+          selected={isEditMode}
+          onChange={() => setIsEditMode((v) => !v)}
+          size="small"
+          color="primary"
+        >
+          {isEditMode ? <EditOff fontSize="small" /> : <Edit fontSize="small" />}
+          <Box component="span" sx={{ ml: 0.5, fontSize: '0.75rem' }}>
+            {isEditMode ? 'Done' : 'Edit Grid'}
+          </Box>
+        </ToggleButton>
+      </Box>
+      <ColorPadGrid venue={venue} isEditMode={isEditMode} />
+
+      <Divider sx={{ my: 3 }} />
+
+      {/* Virtual membership */}
+      <Typography variant="subtitle1" gutterBottom>
+        Virtuals in this venue
+      </Typography>
+      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mb: 2 }}>
+        {memberVirtuals.length === 0 && (
+          <Typography color="text.secondary" variant="body2">
+            No virtuals assigned yet.
+          </Typography>
+        )}
+        {memberVirtuals.map((v) => (
+          <Chip
+            key={v.id}
+            label={v.config?.name ?? v.id}
+            onDelete={() => handleRemoveVirtual(v.id)}
+          />
+        ))}
+      </Box>
+      <Autocomplete
+        options={notYetAdded}
+        getOptionLabel={(v) => v.config?.name ?? v.id}
+        onChange={handleAddVirtual}
+        value={null}
+        disabled={adding}
+        renderInput={(params) => (
+          <TextField {...params} label="Add virtual to venue" size="small" sx={{ maxWidth: 320 }} />
+        )}
+        isOptionEqualToValue={(a, b) => a.id === b.id}
+      />
+    </Box>
+  )
+}

--- a/src/pages/Venues/VenuesPage.tsx
+++ b/src/pages/Venues/VenuesPage.tsx
@@ -1,0 +1,239 @@
+import { useState, useEffect, useCallback } from 'react'
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  CardActions,
+  Typography,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  IconButton,
+  Tooltip
+} from '@mui/material'
+import { Add, Delete, Edit, MeetingRoom } from '@mui/icons-material'
+import useStore from '../../store/useStore'
+import VenueView from './VenueView'
+
+interface CreateVenueDialogProps {
+  open: boolean
+  onClose: () => void
+  onSave: (name: string, rows: number, cols: number) => void
+  initial?: { name: string; rows: number; cols: number }
+}
+
+function CreateVenueDialog({ open, onClose, onSave, initial }: CreateVenueDialogProps) {
+  const [name, setName] = useState(initial?.name ?? '')
+  const [rows, setRows] = useState(initial?.rows ?? 4)
+  const [cols, setCols] = useState(initial?.cols ?? 4)
+
+  useEffect(() => {
+    if (open) {
+      setName(initial?.name ?? '')
+      setRows(initial?.rows ?? 4)
+      setCols(initial?.cols ?? 4)
+    }
+  }, [open, initial?.name, initial?.rows, initial?.cols])
+
+  const handleSave = () => {
+    if (!name.trim()) return
+    onSave(name.trim(), rows, cols)
+    onClose()
+  }
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle>{initial ? 'Edit Venue' : 'Create Venue'}</DialogTitle>
+      <DialogContent>
+        <TextField
+          autoFocus
+          label="Venue name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          fullWidth
+          margin="dense"
+        />
+        <Box sx={{ display: 'flex', gap: 2, mt: 2 }}>
+          <TextField
+            label="Override pad rows"
+            type="number"
+            value={rows}
+            onChange={(e) => setRows(Math.max(1, parseInt(e.target.value) || 1))}
+            slotProps={{ htmlInput: { min: 1, max: 16 } }}
+            size="small"
+          />
+          <TextField
+            label="Override pad cols"
+            type="number"
+            value={cols}
+            onChange={(e) => setCols(Math.max(1, parseInt(e.target.value) || 1))}
+            slotProps={{ htmlInput: { min: 1, max: 16 } }}
+            size="small"
+          />
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button onClick={handleSave} variant="contained" disabled={!name.trim()}>
+          {initial ? 'Save' : 'Create'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}
+
+export default function VenuesPage() {
+  const venues = useStore((state) => state.venues)
+  const activeVenueId = useStore((state) => state.activeVenueId)
+  const getVenues = useStore((state) => state.getVenues)
+  const createVenue = useStore((state) => state.createVenue)
+  const updateVenue = useStore((state) => state.updateVenue)
+  const deleteVenue = useStore((state) => state.deleteVenue)
+  const setActiveVenueId = useStore((state) => state.setActiveVenueId)
+  const clearVenueOverride = useStore((state) => state.clearVenueOverride)
+
+  const [createOpen, setCreateOpen] = useState(false)
+  const [editVenue, setEditVenue] = useState<{ id: string; name: string; rows: number; cols: number } | null>(null)
+
+  useEffect(() => {
+    getVenues()
+  }, [getVenues])
+
+  const handleCreate = useCallback(
+    async (name: string, rows: number, cols: number) => {
+      await createVenue(name, rows, cols)
+    },
+    [createVenue]
+  )
+
+  const handleEdit = useCallback(
+    async (name: string, rows: number, cols: number) => {
+      if (!editVenue) return
+      await updateVenue(editVenue.id, {
+        name,
+        color_pads: { ...venues[editVenue.id]?.color_pads, rows, cols }
+      })
+      setEditVenue(null)
+    },
+    [editVenue, updateVenue, venues]
+  )
+
+  const handleDelete = useCallback(
+    async (venueId: string) => {
+      if (activeVenueId === venueId) {
+        await clearVenueOverride(venueId)
+        setActiveVenueId(null)
+      }
+      await deleteVenue(venueId)
+    },
+    [activeVenueId, clearVenueOverride, setActiveVenueId, deleteVenue]
+  )
+
+  const handleEnter = useCallback(
+    (venueId: string) => {
+      setActiveVenueId(venueId)
+    },
+    [setActiveVenueId]
+  )
+
+  const handleLeave = useCallback(async () => {
+    if (activeVenueId) {
+      await clearVenueOverride(activeVenueId)
+    }
+    setActiveVenueId(null)
+  }, [activeVenueId, clearVenueOverride, setActiveVenueId])
+
+  if (activeVenueId && venues[activeVenueId]) {
+    return <VenueView venue={venues[activeVenueId]} onLeave={handleLeave} />
+  }
+
+  const venueList = Object.values(venues)
+
+  return (
+    <Box sx={{ p: 2 }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', mb: 2, gap: 2 }}>
+        <Typography variant="h5">Venues</Typography>
+        <Button
+          variant="contained"
+          startIcon={<Add />}
+          onClick={() => setCreateOpen(true)}
+          size="small"
+        >
+          New Venue
+        </Button>
+      </Box>
+
+      {venueList.length === 0 ? (
+        <Typography color="text.secondary">
+          No venues yet. Create one to group your devices and use color override pads.
+        </Typography>
+      ) : (
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2 }}>
+          {venueList.map((venue) => (
+            <Box key={venue.id} sx={{ minWidth: 240, maxWidth: 320, flex: '1 1 240px' }}>
+              <Card>
+                <CardContent>
+                  <Typography variant="h6">{venue.name}</Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    {venue.virtual_ids.length} virtual
+                    {venue.virtual_ids.length !== 1 ? 's' : ''}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    {venue.color_pads.rows}×{venue.color_pads.cols} override pad grid
+                  </Typography>
+                </CardContent>
+                <CardActions>
+                  <Button
+                    size="small"
+                    variant="contained"
+                    startIcon={<MeetingRoom />}
+                    onClick={() => handleEnter(venue.id)}
+                  >
+                    Enter
+                  </Button>
+                  <Tooltip title="Edit">
+                    <IconButton
+                      size="small"
+                      onClick={() =>
+                        setEditVenue({
+                          id: venue.id,
+                          name: venue.name,
+                          rows: venue.color_pads.rows,
+                          cols: venue.color_pads.cols
+                        })
+                      }
+                    >
+                      <Edit fontSize="small" />
+                    </IconButton>
+                  </Tooltip>
+                  <Tooltip title="Delete">
+                    <IconButton size="small" onClick={() => handleDelete(venue.id)}>
+                      <Delete fontSize="small" />
+                    </IconButton>
+                  </Tooltip>
+                </CardActions>
+              </Card>
+            </Box>
+          ))}
+        </Box>
+      )}
+
+      <CreateVenueDialog
+        open={createOpen}
+        onClose={() => setCreateOpen(false)}
+        onSave={handleCreate}
+      />
+      {editVenue && (
+        <CreateVenueDialog
+          open={!!editVenue}
+          onClose={() => setEditVenue(null)}
+          onSave={handleEdit}
+          initial={editVenue}
+        />
+      )}
+    </Box>
+  )
+}

--- a/src/pages/Venues/VenuesPage.tsx
+++ b/src/pages/Venues/VenuesPage.tsx
@@ -94,7 +94,12 @@ export default function VenuesPage() {
   const navigate = useNavigate()
 
   const [createOpen, setCreateOpen] = useState(false)
-  const [editVenue, setEditVenue] = useState<{ id: string; name: string; rows: number; cols: number } | null>(null)
+  const [editVenue, setEditVenue] = useState<{
+    id: string
+    name: string
+    rows: number
+    cols: number
+  } | null>(null)
 
   useEffect(() => {
     getVenues()

--- a/src/pages/Venues/VenuesPage.tsx
+++ b/src/pages/Venues/VenuesPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
 import {
   Box,
   Button,
@@ -16,7 +17,6 @@ import {
 } from '@mui/material'
 import { Add, Delete, Edit, MeetingRoom } from '@mui/icons-material'
 import useStore from '../../store/useStore'
-import VenueView from './VenueView'
 
 interface CreateVenueDialogProps {
   open: boolean
@@ -87,13 +87,11 @@ function CreateVenueDialog({ open, onClose, onSave, initial }: CreateVenueDialog
 
 export default function VenuesPage() {
   const venues = useStore((state) => state.venues)
-  const activeVenueId = useStore((state) => state.activeVenueId)
   const getVenues = useStore((state) => state.getVenues)
   const createVenue = useStore((state) => state.createVenue)
   const updateVenue = useStore((state) => state.updateVenue)
   const deleteVenue = useStore((state) => state.deleteVenue)
-  const setActiveVenueId = useStore((state) => state.setActiveVenueId)
-  const clearVenueOverride = useStore((state) => state.clearVenueOverride)
+  const navigate = useNavigate()
 
   const [createOpen, setCreateOpen] = useState(false)
   const [editVenue, setEditVenue] = useState<{ id: string; name: string; rows: number; cols: number } | null>(null)
@@ -123,32 +121,17 @@ export default function VenuesPage() {
 
   const handleDelete = useCallback(
     async (venueId: string) => {
-      if (activeVenueId === venueId) {
-        await clearVenueOverride(venueId)
-        setActiveVenueId(null)
-      }
       await deleteVenue(venueId)
     },
-    [activeVenueId, clearVenueOverride, setActiveVenueId, deleteVenue]
+    [deleteVenue]
   )
 
   const handleEnter = useCallback(
     (venueId: string) => {
-      setActiveVenueId(venueId)
+      navigate('/venues/' + venueId)
     },
-    [setActiveVenueId]
+    [navigate]
   )
-
-  const handleLeave = useCallback(async () => {
-    if (activeVenueId) {
-      await clearVenueOverride(activeVenueId)
-    }
-    setActiveVenueId(null)
-  }, [activeVenueId, clearVenueOverride, setActiveVenueId])
-
-  if (activeVenueId && venues[activeVenueId]) {
-    return <VenueView venue={venues[activeVenueId]} onLeave={handleLeave} />
-  }
 
   const venueList = Object.values(venues)
 

--- a/src/store/api/storeVenues.tsx
+++ b/src/store/api/storeVenues.tsx
@@ -210,4 +210,3 @@ const storeVenues = (set: any) => ({
 })
 
 export default storeVenues
-

--- a/src/store/api/storeVenues.tsx
+++ b/src/store/api/storeVenues.tsx
@@ -160,6 +160,7 @@ const storeVenues = (set: any) => ({
     if (resp) {
       set(
         produce((s: IStore) => {
+          s.activeVenueId = venueId
           s.activeOverridePadIndex = padIndex
         }),
         false,
@@ -175,6 +176,7 @@ const storeVenues = (set: any) => ({
     if (resp) {
       set(
         produce((s: IStore) => {
+          s.activeVenueId = null
           s.activeOverridePadIndex = null
         }),
         false,

--- a/src/store/api/storeVenues.tsx
+++ b/src/store/api/storeVenues.tsx
@@ -66,30 +66,32 @@ const storeVenues = (set: any) => ({
 
   createVenue: async (name: string, rows = 4, cols = 4) => {
     const resp = await Ledfx('/api/venues', 'POST', { name, rows, cols })
-    if (resp && resp.venue) {
+    const venue = resp?.data?.venue
+    if (venue) {
       set(
         produce((s: IStore) => {
-          s.venues[resp.venue.id] = resp.venue
+          s.venues[venue.id] = venue
         }),
         false,
         'venues/created'
       )
-      return resp.venue as Venue
+      return venue as Venue
     }
     return null
   },
 
   updateVenue: async (venueId: string, data: Partial<Pick<Venue, 'name' | 'color_pads'>>) => {
     const resp = await Ledfx(`/api/venues/${venueId}`, 'PUT', data)
-    if (resp && resp.venue) {
+    const venue = resp?.data?.venue
+    if (venue) {
       set(
         produce((s: IStore) => {
-          s.venues[venueId] = resp.venue
+          s.venues[venueId] = venue
         }),
         false,
         'venues/updated'
       )
-      return resp.venue as Venue
+      return venue as Venue
     }
     return null
   },
@@ -118,15 +120,16 @@ const storeVenues = (set: any) => ({
       action: 'add_virtual',
       virtual_id: virtualId
     })
-    if (resp && resp.venue) {
+    const venue = resp?.data?.venue
+    if (venue) {
       set(
         produce((s: IStore) => {
-          s.venues[venueId] = resp.venue
+          s.venues[venueId] = venue
         }),
         false,
         'venues/addedVirtual'
       )
-      return resp.venue as Venue
+      return venue as Venue
     }
     return null
   },
@@ -136,15 +139,16 @@ const storeVenues = (set: any) => ({
       action: 'remove_virtual',
       virtual_id: virtualId
     })
-    if (resp && resp.venue) {
+    const venue = resp?.data?.venue
+    if (venue) {
       set(
         produce((s: IStore) => {
-          s.venues[venueId] = resp.venue
+          s.venues[venueId] = venue
         }),
         false,
         'venues/removedVirtual'
       )
-      return resp.venue as Venue
+      return venue as Venue
     }
     return null
   },
@@ -188,15 +192,16 @@ const storeVenues = (set: any) => ({
     updatedPads[padIndex] = pad
     const updatedColorPads = { ...currentVenue.color_pads, pads: updatedPads }
     const resp = await Ledfx(`/api/venues/${venueId}`, 'PUT', { color_pads: updatedColorPads })
-    if (resp && resp.venue) {
+    const venue = resp?.data?.venue
+    if (venue) {
       set(
         produce((s: IStore) => {
-          s.venues[venueId] = resp.venue
+          s.venues[venueId] = venue
         }),
         false,
         'venues/padUpdated'
       )
-      return resp.venue as Venue
+      return venue as Venue
     }
     return null
   }

--- a/src/store/api/storeVenues.tsx
+++ b/src/store/api/storeVenues.tsx
@@ -1,0 +1,206 @@
+import { produce } from 'immer'
+import { Ledfx } from '../../api/ledfx'
+import type { IStore } from '../useStore'
+import useStore from '../useStore'
+
+export interface ColorPad {
+  color?: string
+  gradient?: string
+}
+
+export interface VenueColorPads {
+  rows: number
+  cols: number
+  pads: ColorPad[]
+}
+
+export interface Venue {
+  id: string
+  name: string
+  virtual_ids: string[]
+  color_pads: VenueColorPads
+}
+
+const storeVenues = (set: any) => ({
+  venues: {} as Record<string, Venue>,
+  activeVenueId: null as string | null,
+  activeOverridePadIndex: null as number | null,
+
+  setActiveVenueId: (id: string | null) =>
+    set(
+      produce((s: IStore) => {
+        s.activeVenueId = id
+        s.activeOverridePadIndex = null
+      }),
+      false,
+      'venues/setActiveVenueId'
+    ),
+
+  setActiveOverridePadIndex: (index: number | null) =>
+    set(
+      produce((s: IStore) => {
+        s.activeOverridePadIndex = index
+      }),
+      false,
+      'venues/setActiveOverridePadIndex'
+    ),
+
+  getVenues: async () => {
+    const resp = await Ledfx('/api/venues')
+    if (resp && resp.venues) {
+      const byId: Record<string, Venue> = {}
+      for (const v of resp.venues) {
+        byId[v.id] = v
+      }
+      set(
+        produce((s: IStore) => {
+          s.venues = byId
+        }),
+        false,
+        'venues/gotVenues'
+      )
+      return byId
+    }
+    return null
+  },
+
+  createVenue: async (name: string, rows = 4, cols = 4) => {
+    const resp = await Ledfx('/api/venues', 'POST', { name, rows, cols })
+    if (resp && resp.venue) {
+      set(
+        produce((s: IStore) => {
+          s.venues[resp.venue.id] = resp.venue
+        }),
+        false,
+        'venues/created'
+      )
+      return resp.venue as Venue
+    }
+    return null
+  },
+
+  updateVenue: async (venueId: string, data: Partial<Pick<Venue, 'name' | 'color_pads'>>) => {
+    const resp = await Ledfx(`/api/venues/${venueId}`, 'PUT', data)
+    if (resp && resp.venue) {
+      set(
+        produce((s: IStore) => {
+          s.venues[venueId] = resp.venue
+        }),
+        false,
+        'venues/updated'
+      )
+      return resp.venue as Venue
+    }
+    return null
+  },
+
+  deleteVenue: async (venueId: string) => {
+    const resp = await Ledfx(`/api/venues/${venueId}`, 'DELETE')
+    if (resp) {
+      set(
+        produce((s: IStore) => {
+          delete s.venues[venueId]
+          if (s.activeVenueId === venueId) {
+            s.activeVenueId = null
+            s.activeOverridePadIndex = null
+          }
+        }),
+        false,
+        'venues/deleted'
+      )
+      return true
+    }
+    return false
+  },
+
+  addVirtualToVenue: async (venueId: string, virtualId: string) => {
+    const resp = await Ledfx(`/api/venues/${venueId}`, 'PUT', {
+      action: 'add_virtual',
+      virtual_id: virtualId
+    })
+    if (resp && resp.venue) {
+      set(
+        produce((s: IStore) => {
+          s.venues[venueId] = resp.venue
+        }),
+        false,
+        'venues/addedVirtual'
+      )
+      return resp.venue as Venue
+    }
+    return null
+  },
+
+  removeVirtualFromVenue: async (venueId: string, virtualId: string) => {
+    const resp = await Ledfx(`/api/venues/${venueId}`, 'PUT', {
+      action: 'remove_virtual',
+      virtual_id: virtualId
+    })
+    if (resp && resp.venue) {
+      set(
+        produce((s: IStore) => {
+          s.venues[venueId] = resp.venue
+        }),
+        false,
+        'venues/removedVirtual'
+      )
+      return resp.venue as Venue
+    }
+    return null
+  },
+
+  activateVenueOverride: async (venueId: string, padIndex: number) => {
+    const resp = await Ledfx(`/api/venues/${venueId}/override`, 'POST', {
+      pad_index: padIndex
+    })
+    if (resp) {
+      set(
+        produce((s: IStore) => {
+          s.activeOverridePadIndex = padIndex
+        }),
+        false,
+        'venues/overrideActivated'
+      )
+      return true
+    }
+    return false
+  },
+
+  clearVenueOverride: async (venueId: string) => {
+    const resp = await Ledfx(`/api/venues/${venueId}/override`, 'DELETE')
+    if (resp) {
+      set(
+        produce((s: IStore) => {
+          s.activeOverridePadIndex = null
+        }),
+        false,
+        'venues/overrideCleared'
+      )
+      return true
+    }
+    return false
+  },
+
+  updateVenuePad: async (venueId: string, padIndex: number, pad: ColorPad) => {
+    const currentVenue = useStore.getState().venues[venueId]
+    if (!currentVenue) return null
+    const updatedPads = [...currentVenue.color_pads.pads]
+    updatedPads[padIndex] = pad
+    const updatedColorPads = { ...currentVenue.color_pads, pads: updatedPads }
+    const resp = await Ledfx(`/api/venues/${venueId}`, 'PUT', { color_pads: updatedColorPads })
+    if (resp && resp.venue) {
+      set(
+        produce((s: IStore) => {
+          s.venues[venueId] = resp.venue
+        }),
+        false,
+        'venues/padUpdated'
+      )
+      return resp.venue as Venue
+    }
+    return null
+  }
+})
+
+export default storeVenues
+

--- a/src/store/useStore.ts
+++ b/src/store/useStore.ts
@@ -38,6 +38,7 @@ import storeClientIdentity from './ui/storeClientIdentity'
 import storeClients from './api/storeClients'
 import storeVisualizerConfigOptimistic from './ui-persist/storeVisualizerConfigOptimistic'
 import storeSendspin from './api/storeSendspin'
+import storeVenues from './api/storeVenues'
 
 const useStore = create(
   devtools(
@@ -81,7 +82,8 @@ const useStore = create(
           ...storeClients(set),
           ...storeCloud(set),
           ...storeVisualizerConfigOptimistic(set),
-          ...storeSendspin(set)
+          ...storeSendspin(set),
+          ...storeVenues(set)
         })
       ),
       {
@@ -109,7 +111,9 @@ const useStore = create(
                   'spotify',
                   'pixelGraphs',
                   'externalStudioRef',
-                  'clientIdentity'
+                  'clientIdentity',
+                  'activeVenueId',
+                  'activeOverridePadIndex'
                 ].includes(key)
             )
           )


### PR DESCRIPTION
## Summary

Adds a **Venues** system: group virtual devices into a physical space ("venue") and control a shared color/gradient override across them from a single pad grid, without interrupting the running effect's animation.

### Features
- **Venue CRUD** — create, rename, delete venues; each venue has a configurable pad grid (rows x cols).
- **Exclusive virtual membership** — a virtual can belong to at most one venue at a time; adding it to a venue removes it from any other.
- **Pad grid with HSV auto-palette** — each pad auto-generates a color from an HSV palette, with an inline color/gradient picker to customize.
- **Live preview** — per-virtual PixelGraph preview reflecting the venue's current state.
- **Color/gradient override** — activating a pad tints the currently running effect on all virtuals in the venue (color or gradient) without freezing/restarting the effect's animation; clearing the override reverts to normal effect rendering.
- Misc fixes carried with the feature: segment editor dialog fixes, Venues nav moved to the bottom bar, pad sizing/zoom, gradient picker/theme/angle fixes, immediate UI updates, and permalink support for a venue view.

### Test coverage
- `playwright/tests/venues.spec.ts` (new): end-to-end flow — create a virtual device, create a venue, add the virtual to the venue, activate a color override on a pad, verify it applies (ON badge / "Override Active" indicator), then clear the override and verify it's removed.
- Existing suite verified green alongside this change: `add-virtual.spec.ts`, `matrix-device.spec.ts`, `visualiser-features.spec.ts`.
- `yarn test:types` and `yarn test:lint` pass with no new errors introduced (pre-existing, unrelated baseline lint errors in 3 untouched files are unaffected by this change).

### Scope note
This PR intentionally excludes an unrelated DMX Input integration UI feature that was mixed into the original fork branch; that will be proposed separately.