### PR TITLE
Feat(dmx_input): SoundSwitch/Art-Net DMX Input settings UI

### DIFF
--- a/playwright/tests/dmx-input.spec.ts
+++ b/playwright/tests/dmx-input.spec.ts
@@ -185,5 +185,6 @@ test('DMX Input: add integration, activate, and configure a mapping', async ({ p
     // "Virtual: ..." prefix rather than requiring an exact name match.
     await expect(mappingRow.getByText(/^Virtual: /)).toBeVisible()
     await page.screenshot({ path: 'test-results/dmx-8-mapping-saved.png' })
+    await page.screenshot({ path: 'playwright/screenshots/dmx-input-mapping.png', fullPage: true })
   })
 })

--- a/playwright/tests/dmx-input.spec.ts
+++ b/playwright/tests/dmx-input.spec.ts
@@ -141,8 +141,9 @@ test('DMX Input: add integration, activate, and configure a mapping', async ({ p
   /**
    * @doc
    * Open the integration's settings screen and add a **Fixture** mapping —
-   * this drives a Virtual as a dumb DMX wash (mode/dimmer/RGB channels)
-   * rather than needing a Venue to exist.
+   * this drives a Virtual as a dumb DMX wash (dimmer/RGB channels, engaged
+   * continuously with no on/off threshold) rather than needing a Venue to
+   * exist.
    */
   await test.step('5. Configure a Fixture Mapping', async () => {
     const card = page.locator('.MuiCard-root').filter({ hasText: 'DMX Input' }).first()

--- a/playwright/tests/dmx-input.spec.ts
+++ b/playwright/tests/dmx-input.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { test, expect } from './fixtures'
 import { clearDialogs } from './helpers'
 
@@ -131,7 +130,10 @@ test('DMX Input: add integration, activate, and configure a mapping', async ({ p
     await expect(async () => {
       await page.locator('.MuiBottomNavigationAction-root').filter({ hasText: 'Devices' }).click()
       await page.waitForTimeout(300)
-      await page.locator('.MuiBottomNavigationAction-root').filter({ hasText: 'Integrations' }).click()
+      await page
+        .locator('.MuiBottomNavigationAction-root')
+        .filter({ hasText: 'Integrations' })
+        .click()
       await expect(card.getByText('Current Status: Listening')).toBeVisible({ timeout: 3000 })
     }).toPass({ timeout: 20000 })
 
@@ -143,7 +145,8 @@ test('DMX Input: add integration, activate, and configure a mapping', async ({ p
    * Open the integration's settings screen and add a **Fixture** mapping —
    * this drives a Virtual as a dumb DMX wash (dimmer/RGB channels, engaged
    * continuously with no on/off threshold) rather than needing a Venue to
-   * exist.
+   * exist. Also exercise the new **Strobe randomness** slider (only shown
+   * for the Fixture type).
    */
   await test.step('5. Configure a Fixture Mapping', async () => {
     const card = page.locator('.MuiCard-root').filter({ hasText: 'DMX Input' }).first()
@@ -159,9 +162,21 @@ test('DMX Input: add integration, activate, and configure a mapping', async ({ p
     await mappingDialog.waitFor({ state: 'visible' })
 
     await mappingDialog.getByLabel('Name').fill(mappingName)
-    await mappingDialog.getByLabel('Type').click()
+    await mappingDialog.getByLabel('Type', { exact: true }).click()
     await page.getByRole('option', { name: 'Fixture (wash)' }).click()
     await page.waitForTimeout(500)
+
+    // The Strobe randomness slider only appears for the Fixture type.
+    const strobeSlider = mappingDialog.getByRole('slider', { name: 'Strobe randomness' })
+    await expect(strobeSlider).toBeVisible()
+    await expect(mappingDialog.getByText('Strobe randomness: 0%')).toBeVisible()
+
+    // Drag it up to 40% via keyboard (more reliable than pointer drag math).
+    await strobeSlider.focus()
+    for (let i = 0; i < 8; i += 1) {
+      await strobeSlider.press('ArrowRight')
+    }
+    await expect(mappingDialog.getByText('Strobe randomness: 40%')).toBeVisible()
     await page.screenshot({ path: 'test-results/dmx-7-mapping-dialog.png' })
 
     const saveButton = mappingDialog.getByRole('button', { name: 'Save' })
@@ -187,5 +202,40 @@ test('DMX Input: add integration, activate, and configure a mapping', async ({ p
     await expect(mappingRow.getByText(/^Virtual: /)).toBeVisible()
     await page.screenshot({ path: 'test-results/dmx-8-mapping-saved.png' })
     await page.screenshot({ path: 'playwright/screenshots/dmx-input-mapping.png', fullPage: true })
+  })
+
+  /**
+   * @doc
+   * Regression coverage for the per-type mapping config cache: re-open the
+   * saved Fixture mapping, confirm the Strobe randomness setting persisted
+   * (survives a full save/reload round-trip, not just the open dialog
+   * session), switch its type to Color and back to Fixture, and confirm the
+   * Fixture-specific fields (channels, strobe randomness) were restored
+   * from cache instead of reset to schema defaults.
+   */
+  await test.step('7. Strobe randomness persists and survives a type switch', async () => {
+    const screen = page.getByRole('dialog').filter({ hasText: 'DMX Input Mappings' })
+    const mappingRow = screen.locator('tr').filter({ hasText: mappingName })
+    await mappingRow.getByRole('button', { name: 'Edit' }).click()
+
+    const mappingDialog = page.getByRole('dialog').filter({ hasText: 'Edit DMX Mapping' })
+    await mappingDialog.waitFor({ state: 'visible' })
+    await expect(mappingDialog.getByText('Strobe randomness: 40%')).toBeVisible()
+
+    // Switch away to Color, then back to Fixture — the cache must restore
+    // both the strobe setting and the channel values instead of resetting.
+    await mappingDialog.getByLabel('Type', { exact: true }).click()
+    await page.getByRole('option', { name: 'Color (live RGB)' }).click()
+    await page.waitForTimeout(300)
+    await mappingDialog.getByLabel('Type', { exact: true }).click()
+    await page.getByRole('option', { name: 'Fixture (wash)' }).click()
+    await page.waitForTimeout(300)
+
+    await expect(mappingDialog.getByText('Strobe randomness: 40%')).toBeVisible()
+    await expect(mappingDialog.getByLabel('Dimmer ch')).toHaveValue('1')
+    await page.screenshot({ path: 'test-results/dmx-9-type-cache-restored.png' })
+
+    await mappingDialog.getByRole('button', { name: 'Cancel' }).click()
+    await mappingDialog.waitFor({ state: 'detached', timeout: 10000 })
   })
 })

--- a/playwright/tests/dmx-input.spec.ts
+++ b/playwright/tests/dmx-input.spec.ts
@@ -1,0 +1,189 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { test, expect } from './fixtures'
+import { clearDialogs } from './helpers'
+
+/**
+ * @title How to: Configure the DMX Input Integration
+ * @intro
+ * The **DMX Input** integration bridges incoming Art-Net DMX (e.g. from
+ * SoundSwitch) onto LedFx: channel **mappings** can trigger venue color
+ * overrides, pass live RGB straight through, or drive a virtual as a dumb
+ * DMX wash fixture. This guide adds the integration, activates it, and
+ * configures a Fixture mapping targeting a Virtual.
+ */
+test('DMX Input: add integration, activate, and configure a mapping', async ({ page }) => {
+  test.setTimeout(90000)
+
+  await page.goto('/#/')
+  await clearDialogs(page)
+
+  const virtualName = 'DMX Test Virtual'
+  const mappingName = 'Test DMX Mapping'
+
+  /**
+   * @doc
+   * Create a Virtual Device from the **Devices** page FAB so there is a
+   * target for the DMX mapping.
+   */
+  await test.step('1. Create a Virtual Device', async () => {
+    await page.locator('.MuiBottomNavigationAction-root').filter({ hasText: 'Devices' }).click()
+    await page.waitForTimeout(1000)
+
+    await page.locator('.MuiFab-root[aria-label="add"]').click()
+    await page.waitForTimeout(500)
+    await page.getByRole('menuitem', { name: 'Add Virtual' }).click()
+
+    const dialog = page.getByRole('dialog')
+    await dialog.waitFor({ state: 'visible' })
+    const nameInput = dialog.locator('input').first()
+    await nameInput.waitFor({ state: 'visible', timeout: 10000 })
+    await nameInput.fill(virtualName)
+
+    await page.getByRole('button', { name: 'Add & Setup Segments' }).click()
+    await page.waitForTimeout(2000)
+
+    // "Add & Setup Segments" opens the full-screen segment editor — go Back
+    await page.getByRole('button', { name: 'Back' }).click()
+    await page.waitForTimeout(500)
+    await page.screenshot({ path: 'test-results/dmx-1-virtual-created.png' })
+  })
+
+  /**
+   * @doc
+   * The **Integrations** page is hidden behind a feature flag, and the
+   * **Features** accordion that exposes it only appears in **Expert Mode**.
+   * Open **Settings**, enable Expert Mode, then expand **Features** and
+   * enable **Integrations (Spotify, MQTT, HA, ...)**.
+   */
+  await test.step('2. Enable the Integrations Feature Flag', async () => {
+    await page.locator('.MuiBottomNavigationAction-root').filter({ hasText: 'Settings' }).click()
+    await page.waitForTimeout(1000)
+
+    const expertCheckbox = page.getByLabel('Expert Mode')
+    await expertCheckbox.waitFor({ state: 'visible' })
+    if (!(await expertCheckbox.isChecked())) {
+      await expertCheckbox.click()
+      await page.waitForTimeout(500)
+    }
+
+    const featuresAccordion = page.getByRole('button', { name: /Features/ })
+    await featuresAccordion.click()
+    await page.waitForTimeout(500)
+
+    // "Integrations" is the first switch inside the "Features" region —
+    // select by position within the region rather than by label text, since
+    // the label text is split across sibling nodes and ancestor divs all
+    // "contain" it, making text-based filters ambiguous.
+    const featuresRegion = page.getByRole('region', { name: 'Features' })
+    const integrationsRow = featuresRegion.locator('input[type="checkbox"]').first()
+    await integrationsRow.waitFor({ state: 'visible' })
+    if (!(await integrationsRow.isChecked())) {
+      await integrationsRow.click()
+      await page.waitForTimeout(500)
+    }
+    await page.screenshot({ path: 'test-results/dmx-2-feature-flag.png' })
+  })
+
+  /**
+   * @doc
+   * Navigate to **Integrations** and use the FAB's **Add Integration**
+   * action. Pick **DMX Input** as the type — every field has a sensible
+   * default (bind address, Art-Net port, etc.) so it can be added as-is.
+   */
+  await test.step('3. Add the DMX Input Integration', async () => {
+    await page
+      .locator('.MuiBottomNavigationAction-root')
+      .filter({ hasText: 'Integrations' })
+      .click()
+    await page.waitForTimeout(1000)
+
+    await page.locator('.MuiFab-root[aria-label="add"]').click()
+    await page.waitForTimeout(500)
+    await page.getByRole('menuitem', { name: 'Add Integration' }).click()
+
+    const dialog = page.getByRole('dialog')
+    await dialog.waitFor({ state: 'visible' })
+    await dialog.getByRole('combobox').first().click()
+    await page.getByRole('option', { name: 'DMX Input' }).click()
+    await page.waitForTimeout(500)
+    await page.screenshot({ path: 'test-results/dmx-3-add-dialog.png' })
+
+    await dialog.getByRole('button', { name: 'Add' }).click()
+    await dialog.waitFor({ state: 'detached', timeout: 10000 })
+
+    await expect(page.getByText('DMX Input').first()).toBeVisible({ timeout: 10000 })
+    await page.screenshot({ path: 'test-results/dmx-4-integration-added.png' })
+  })
+
+  /**
+   * @doc
+   * Flip the integration's status switch to activate it. Once the Art-Net
+   * listener binds, the card's status updates to **Listening** and the
+   * settings (gear) button becomes enabled.
+   */
+  await test.step('4. Activate the Integration', async () => {
+    const card = page.locator('.MuiCard-root').filter({ hasText: 'DMX Input' }).first()
+    await card.getByRole('switch').click()
+
+    // The card's live status text only refreshes on mount (no websocket
+    // push for integration status), so force a refetch by navigating away
+    // and back to the Integrations page.
+    await expect(async () => {
+      await page.locator('.MuiBottomNavigationAction-root').filter({ hasText: 'Devices' }).click()
+      await page.waitForTimeout(300)
+      await page.locator('.MuiBottomNavigationAction-root').filter({ hasText: 'Integrations' }).click()
+      await expect(card.getByText('Current Status: Listening')).toBeVisible({ timeout: 3000 })
+    }).toPass({ timeout: 20000 })
+
+    await page.screenshot({ path: 'test-results/dmx-5-listening.png' })
+  })
+
+  /**
+   * @doc
+   * Open the integration's settings screen and add a **Fixture** mapping —
+   * this drives a Virtual as a dumb DMX wash (mode/dimmer/RGB channels)
+   * rather than needing a Venue to exist.
+   */
+  await test.step('5. Configure a Fixture Mapping', async () => {
+    const card = page.locator('.MuiCard-root').filter({ hasText: 'DMX Input' }).first()
+    await card.getByRole('button', { name: 'DMX Input settings' }).click()
+
+    const screen = page.getByRole('dialog').filter({ hasText: 'DMX Input Mappings' })
+    await screen.waitFor({ state: 'visible' })
+    await page.screenshot({ path: 'test-results/dmx-6-settings-screen.png' })
+
+    await screen.getByRole('button', { name: 'Add Mapping' }).click()
+
+    const mappingDialog = page.getByRole('dialog').filter({ hasText: 'Add DMX Mapping' })
+    await mappingDialog.waitFor({ state: 'visible' })
+
+    await mappingDialog.getByLabel('Name').fill(mappingName)
+    await mappingDialog.getByLabel('Type').click()
+    await page.getByRole('option', { name: 'Fixture (wash)' }).click()
+    await page.waitForTimeout(500)
+    await page.screenshot({ path: 'test-results/dmx-7-mapping-dialog.png' })
+
+    const saveButton = mappingDialog.getByRole('button', { name: 'Save' })
+    await expect(saveButton).toBeEnabled({ timeout: 10000 })
+    await saveButton.click()
+    await mappingDialog.waitFor({ state: 'detached', timeout: 10000 })
+  })
+
+  /**
+   * @doc
+   * Verify the new mapping saved and displays correctly in the mapping
+   * table, targeting the Virtual created in step 1.
+   */
+  await test.step('6. Verify the Mapping Displays Correctly', async () => {
+    const screen = page.getByRole('dialog').filter({ hasText: 'DMX Input Mappings' })
+    const mappingRow = screen.locator('tr').filter({ hasText: mappingName })
+
+    await expect(mappingRow).toBeVisible({ timeout: 10000 })
+    await expect(mappingRow.getByText('fixture', { exact: true })).toBeVisible()
+    // The displayed virtual name comes straight from the backend's virtuals
+    // lookup and may normalize/trim the name we submitted, so assert on the
+    // "Virtual: ..." prefix rather than requiring an exact name match.
+    await expect(mappingRow.getByText(/^Virtual: /)).toBeVisible()
+    await page.screenshot({ path: 'test-results/dmx-8-mapping-saved.png' })
+  })
+})

--- a/playwright/tests/global.setup.ts
+++ b/playwright/tests/global.setup.ts
@@ -31,7 +31,7 @@ async function waitForBackend(timeoutMs = 60000): Promise<void> {
 }
 
 /** Poll frontend until /manifest.json responds with a name containing 'LedFx' */
-async function waitForFrontend(timeoutMs = 60000): Promise<void> {
+async function waitForFrontend(timeoutMs = 180000): Promise<void> {
   const url = 'http://localhost:2000/manifest.json'
   const deadline = Date.now() + timeoutMs
   while (Date.now() < deadline) {

--- a/playwright/tests/venues.spec.ts
+++ b/playwright/tests/venues.spec.ts
@@ -1,0 +1,141 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { test, expect } from './fixtures'
+import { clearDialogs } from './helpers'
+
+/**
+ * @title How to: Use Venues with Color Override Pads
+ * @intro
+ * **Venues** group one or more Virtuals together and expose a grid of **color
+ * override pads**. Tapping a pad tints every virtual in the venue with that
+ * pad's color/gradient — without interrupting the running effect's animation.
+ * Tapping the active pad again clears the override and restores normal
+ * playback.
+ */
+test('Venues: create venue, add virtual, activate and clear color override', async ({
+  page
+}) => {
+  test.setTimeout(90000)
+
+  await page.goto('/#/')
+  await clearDialogs(page)
+
+  const virtualName = 'Venue Test Virtual'
+  const venueName = 'Test Venue'
+
+  /**
+   * @doc
+   * Create a Virtual Device from the **Devices** page FAB so there is something
+   * to add to the venue.
+   */
+  await test.step('1. Create a Virtual Device', async () => {
+    await page.locator('.MuiBottomNavigationAction-root').filter({ hasText: 'Devices' }).click()
+    await page.waitForTimeout(1000)
+
+    await page.locator('.MuiFab-root[aria-label="add"]').click()
+    await page.waitForTimeout(500)
+    await page.getByRole('menuitem', { name: 'Add Virtual' }).click()
+
+    const dialog = page.getByRole('dialog')
+    await dialog.waitFor({ state: 'visible' })
+    const nameInput = dialog.locator('input').first()
+    await nameInput.waitFor({ state: 'visible', timeout: 10000 })
+    await nameInput.fill(virtualName)
+
+    await page.getByRole('button', { name: 'Add & Setup Segments' }).click()
+    await page.waitForTimeout(2000)
+
+    // "Add & Setup Segments" opens the full-screen segment editor — go Back
+    await page.getByRole('button', { name: 'Back' }).click()
+    await page.waitForTimeout(500)
+    await page.screenshot({ path: 'test-results/venues-1-virtual-created.png' })
+  })
+
+  /**
+   * @doc
+   * Navigate to the **Venues** tab in the bottom bar and click **New Venue**.
+   * Give it a name and confirm the default 4×4 override pad grid with
+   * **Create**.
+   */
+  await test.step('2. Create a Venue', async () => {
+    await page.locator('.MuiBottomNavigationAction-root').filter({ hasText: 'Venues' }).click()
+    await page.waitForTimeout(1000)
+
+    await page.getByRole('button', { name: 'New Venue' }).click()
+    const dialog = page.getByRole('dialog')
+    await dialog.waitFor({ state: 'visible' })
+    await dialog.getByLabel('Venue name').fill(venueName)
+    await page.screenshot({ path: 'test-results/venues-2-create-dialog.png' })
+
+    await dialog.getByRole('button', { name: 'Create' }).click()
+    await dialog.waitFor({ state: 'detached', timeout: 10000 })
+
+    await expect(page.getByText(venueName).first()).toBeVisible({ timeout: 10000 })
+    await page.screenshot({ path: 'test-results/venues-3-venue-created.png' })
+  })
+
+  /**
+   * @doc
+   * Click **Enter** on the venue card to open its detail page.
+   */
+  await test.step('3. Enter the Venue', async () => {
+    const venueCard = page.locator('.MuiCard-root').filter({ hasText: venueName }).first()
+    await venueCard.getByRole('button', { name: 'Enter' }).click()
+    await page.waitForURL(/\/venues\//, { timeout: 10000 })
+    await page.waitForTimeout(1000)
+    await page.screenshot({ path: 'test-results/venues-4-venue-view.png' })
+  })
+
+  /**
+   * @doc
+   * Use the **Add virtual to venue** autocomplete to add the Virtual created
+   * in step 1. Once added, it appears both as a removable chip under
+   * "Virtuals in this venue" and with a live preview pixel graph.
+   */
+  await test.step('4. Add the Virtual to the Venue', async () => {
+    const addVirtualInput = page.getByRole('combobox', { name: 'Add virtual to venue' })
+    await addVirtualInput.click()
+    await addVirtualInput.fill(virtualName)
+    await page.getByRole('option', { name: virtualName }).click()
+    await page.waitForTimeout(1000)
+
+    await expect(
+      page.locator('.MuiChip-root').filter({ hasText: virtualName })
+    ).toBeVisible({
+      timeout: 10000
+    })
+    await page.screenshot({ path: 'test-results/venues-5-virtual-added.png' })
+  })
+
+  /**
+   * @doc
+   * Tap the first color override pad. This activates the override: the pad
+   * shows an **ON** badge and an **Override Active** chip appears above the
+   * live preview, confirming the tint was applied without freezing the
+   * running effect's animation.
+   */
+  await test.step('5. Activate a Color Override Pad', async () => {
+    const firstPad = page.getByTestId('color-pad-0')
+    await firstPad.click()
+    await page.waitForTimeout(1000)
+
+    await expect(firstPad.getByText('ON')).toBeVisible({ timeout: 10000 })
+    await expect(page.getByText('Override Active')).toBeVisible({ timeout: 10000 })
+    await page.screenshot({ path: 'test-results/venues-6-override-active.png' })
+  })
+
+  /**
+   * @doc
+   * Tap the same pad again to clear the override. The **ON** badge and the
+   * **Override Active** chip both disappear, confirming normal playback
+   * resumed.
+   */
+  await test.step('6. Clear the Color Override', async () => {
+    const firstPad = page.getByTestId('color-pad-0')
+    await firstPad.click()
+    await page.waitForTimeout(1000)
+
+    await expect(firstPad.getByText('ON')).not.toBeVisible({ timeout: 10000 })
+    await expect(page.getByText('Override Active')).not.toBeVisible({ timeout: 10000 })
+    await page.screenshot({ path: 'test-results/venues-7-override-cleared.png' })
+  })
+})

--- a/playwright/tests/venues.spec.ts
+++ b/playwright/tests/venues.spec.ts
@@ -121,6 +121,7 @@ test('Venues: create venue, add virtual, activate and clear color override', asy
     await expect(firstPad.getByText('ON')).toBeVisible({ timeout: 10000 })
     await expect(page.getByText('Override Active')).toBeVisible({ timeout: 10000 })
     await page.screenshot({ path: 'test-results/venues-6-override-active.png' })
+    await page.screenshot({ path: 'playwright/screenshots/venues-override.png', fullPage: true })
   })
 
   /**

--- a/playwright/videos/README.md
+++ b/playwright/videos/README.md
@@ -1,1 +1,0 @@
-Generated Videos will be placed here

--- a/src/components/Bars/BarBottom.tsx
+++ b/src/components/Bars/BarBottom.tsx
@@ -6,7 +6,8 @@ import {
   Dashboard,
   ElectricalServices,
   QueueMusic,
-  AccountTree
+  AccountTree,
+  MeetingRoom
 } from '@mui/icons-material'
 import { useLocation, Link } from 'react-router-dom'
 import useStore from '../../store/useStore'
@@ -189,6 +190,15 @@ export default function BarBottom() {
           value="/Scenes"
           icon={<BladeIcon name="mdi:image" />}
           style={bottomBarOpen.indexOf('Scenes') > -1 ? { color: theme.palette.primary.main } : {}}
+        />
+
+        <BottomNavigationAction
+          component={Link}
+          to="/venues"
+          label="Venues"
+          value="/venues"
+          icon={<MeetingRoom />}
+          style={bottomBarOpen.indexOf('venues') > -1 ? { color: theme.palette.primary.main } : {}}
         />
 
         {features.showPlaylistInBottomBar &&

--- a/src/components/Bars/BarLeft.tsx
+++ b/src/components/Bars/BarLeft.tsx
@@ -1,6 +1,6 @@
 import { useTheme } from '@mui/material/styles'
 import useMediaQuery from '@mui/material/useMediaQuery'
-import { ChevronLeft, ChevronRight, MeetingRoom } from '@mui/icons-material'
+import { ChevronLeft, ChevronRight } from '@mui/icons-material'
 import {
   ListItem,
   ListItemIcon,
@@ -174,31 +174,6 @@ const LeftBar = () => {
               </ListItem>
             </Link>
           ))}
-      </List>
-      <Divider />
-      <List>
-        <Link style={{ textDecoration: 'none' }} to="/venues">
-          <ListItem
-            sx={
-              pathname === '/venues'
-                ? {
-                    backgroundColor: theme.palette.secondary.main,
-                    boxShadow: theme.shadows[12],
-                    '&:hover,&:focus,&:visited,&': {
-                      backgroundColor: theme.palette.secondary.main,
-                      boxShadow: theme.shadows[12]
-                    },
-                    color: '#fff'
-                  }
-                : {}
-            }
-          >
-            <ListItemIcon>
-              <MeetingRoom />
-            </ListItemIcon>
-            <ListItemText primary="Venues" />
-          </ListItem>
-        </Link>
       </List>
       <Divider />
     </Drawer>

--- a/src/components/Bars/BarLeft.tsx
+++ b/src/components/Bars/BarLeft.tsx
@@ -1,6 +1,6 @@
 import { useTheme } from '@mui/material/styles'
 import useMediaQuery from '@mui/material/useMediaQuery'
-import { ChevronLeft, ChevronRight } from '@mui/icons-material'
+import { ChevronLeft, ChevronRight, MeetingRoom } from '@mui/icons-material'
 import {
   ListItem,
   ListItemIcon,
@@ -174,6 +174,31 @@ const LeftBar = () => {
               </ListItem>
             </Link>
           ))}
+      </List>
+      <Divider />
+      <List>
+        <Link style={{ textDecoration: 'none' }} to="/venues">
+          <ListItem
+            sx={
+              pathname === '/venues'
+                ? {
+                    backgroundColor: theme.palette.secondary.main,
+                    boxShadow: theme.shadows[12],
+                    '&:hover,&:focus,&:visited,&': {
+                      backgroundColor: theme.palette.secondary.main,
+                      boxShadow: theme.shadows[12]
+                    },
+                    color: '#fff'
+                  }
+                : {}
+            }
+          >
+            <ListItemIcon>
+              <MeetingRoom />
+            </ListItemIcon>
+            <ListItemText primary="Venues" />
+          </ListItem>
+        </Link>
       </List>
       <Divider />
     </Drawer>

--- a/src/components/Dialogs/AddExistingSegmentDialog.tsx
+++ b/src/components/Dialogs/AddExistingSegmentDialog.tsx
@@ -75,7 +75,11 @@ function ConfirmationDialogRaw(props: ConfirmationDialogRawProps) {
 
   // Build a flat list of individual selectable segments across all virtuals
   // Each entry: { label, segment: [deviceId, start, end, invert] }
-  const segmentOptions: Array<{ label: string; segment: [string, number, number, boolean]; isDevice: boolean }> = []
+  const segmentOptions: Array<{
+    label: string
+    segment: [string, number, number, boolean]
+    isDevice: boolean
+  }> = []
   for (const vKey of virtualKeys) {
     const virt = virtuals[vKey]
     const segs = virt.segments || []
@@ -112,9 +116,7 @@ function ConfirmationDialogRaw(props: ConfirmationDialogRawProps) {
           <Select value={value} style={{ width: '100%' }} onChange={handleChange}>
             {segmentOptions.map((opt, idx) => (
               <MenuItem value={JSON.stringify(opt.segment)} key={idx}>
-                {!opt.isDevice && (
-                  <SubdirectoryArrowRight color="disabled" sx={{ mr: 1 }} />
-                )}
+                {!opt.isDevice && <SubdirectoryArrowRight color="disabled" sx={{ mr: 1 }} />}
                 {opt.label}
               </MenuItem>
             ))}

--- a/src/components/Dialogs/AddExistingSegmentDialog.tsx
+++ b/src/components/Dialogs/AddExistingSegmentDialog.tsx
@@ -72,14 +72,32 @@ function ConfirmationDialogRaw(props: ConfirmationDialogRawProps) {
       }
     })
     .filter((v) => (showGaps ? v : !v.startsWith('gap-')))
-    .filter((v) => virtuals[v].segments.length === 1)
 
-  const segments = virtualKeys.reduce((acc: any, v) => {
-    acc[virtuals[v].config.name] = virtuals[v].segments.flat()
-    return acc
-  }, {})
+  // Build a flat list of individual selectable segments across all virtuals
+  // Each entry: { label, segment: [deviceId, start, end, invert] }
+  const segmentOptions: Array<{ label: string; segment: [string, number, number, boolean]; isDevice: boolean }> = []
+  for (const vKey of virtualKeys) {
+    const virt = virtuals[vKey]
+    const segs = virt.segments || []
+    if (segs.length === 0) continue
+    const name = virt.config?.name ?? vKey
+    if (segs.length === 1) {
+      segmentOptions.push({
+        label: name,
+        segment: segs[0] as [string, number, number, boolean],
+        isDevice: !!virt.is_device
+      })
+    } else {
+      segs.forEach((seg: any, idx: number) => {
+        segmentOptions.push({
+          label: `${name} — seg ${idx + 1}`,
+          segment: seg as [string, number, number, boolean],
+          isDevice: !!virt.is_device
+        })
+      })
+    }
+  }
 
-  // console.log(segments)
   return (
     <Dialog
       disableEscapeKeyDown
@@ -92,19 +110,14 @@ function ConfirmationDialogRaw(props: ConfirmationDialogRawProps) {
       <DialogContent dividers>
         <BladeFrame full>
           <Select value={value} style={{ width: '100%' }} onChange={handleChange}>
-            {Object.keys(segments).map((v) => {
-              const k = virtualKeys.find((vi) => virtuals[vi].config.name === v)
-              return (
-                <MenuItem value={JSON.stringify({ [v]: segments[v] })} key={v}>
-                  {k && virtuals[k].is_device ? (
-                    ''
-                  ) : (
-                    <SubdirectoryArrowRight color="disabled" sx={{ mr: 1 }} />
-                  )}
-                  {v}
-                </MenuItem>
-              )
-            })}
+            {segmentOptions.map((opt, idx) => (
+              <MenuItem value={JSON.stringify(opt.segment)} key={idx}>
+                {!opt.isDevice && (
+                  <SubdirectoryArrowRight color="disabled" sx={{ mr: 1 }} />
+                )}
+                {opt.label}
+              </MenuItem>
+            ))}
           </Select>
         </BladeFrame>
       </DialogContent>
@@ -138,45 +151,39 @@ function AddExistingSegmentDialog({ virtual, config = {} }: { virtual: any; conf
     if (!newValue) {
       return
     }
-    const [name, segments] = Object.entries(JSON.parse(newValue))[0] as [
-      string,
-      [string, number, number, boolean]
-    ]
-    // console.log(name)
-    // console.log(segments)
-    if (name && segments) {
-      const deviceKey = Object.keys(deviceList).find((d) => deviceList[d].id === segments[0])
-      const device = deviceKey ? deviceList[deviceKey] : undefined
-      // console.log(device)
-      const temp = [...virtual.segments, segments]
-      const test = temp.filter((t) => t.length === 4)
+    // newValue is now a JSON-stringified [deviceId, start, end, invert] segment
+    const segments = JSON.parse(newValue) as [string, number, number, boolean]
+    if (!Array.isArray(segments) || segments.length !== 4) return
+    const deviceKey = Object.keys(deviceList).find((d) => deviceList[d].id === segments[0])
+    const device = deviceKey ? deviceList[deviceKey] : undefined
+    const temp = [...virtual.segments, segments]
+    const test = temp.filter((t: any) => t.length === 4)
 
-      updateSegments(virtual.id, test).then(() => {
-        getVirtuals()
-        if (device && virtual.active === false && virtual.segments.length === 0) {
-          if (
-            device.active_virtuals &&
-            device.active_virtuals[0] &&
-            virtuals &&
-            virtuals[device.active_virtuals[0]] &&
-            virtuals[device.active_virtuals[0]].effect &&
-            virtuals[device.active_virtuals[0]].effect.type
-          ) {
-            setEffect(
-              virtual.id,
-              virtuals[device.active_virtuals[0]].effect.type as string,
-              virtuals[device.active_virtuals[0]].effect.config,
-              true
-            )
-          } else {
-            setEffect(virtual.id, 'rainbow', {}, true)
-          }
+    updateSegments(virtual.id, test).then(() => {
+      getVirtuals()
+      if (device && virtual.active === false && virtual.segments.length === 0) {
+        if (
+          device.active_virtuals &&
+          device.active_virtuals[0] &&
+          virtuals &&
+          virtuals[device.active_virtuals[0]] &&
+          virtuals[device.active_virtuals[0]].effect &&
+          virtuals[device.active_virtuals[0]].effect.type
+        ) {
+          setEffect(
+            virtual.id,
+            virtuals[device.active_virtuals[0]].effect.type as string,
+            virtuals[device.active_virtuals[0]].effect.config,
+            true
+          )
+        } else {
+          setEffect(virtual.id, 'rainbow', {}, true)
         }
-        if (device) {
-          highlightSegment(virtual.id, device.id, segments[1], segments[2], false)
-        }
-      })
-    }
+      }
+      if (device) {
+        highlightSegment(virtual.id, device.id, segments[1], segments[2], false)
+      }
+    })
   }
 
   return (

--- a/src/components/Integrations/DmxInput/DialogAddDmxMapping.tsx
+++ b/src/components/Integrations/DmxInput/DialogAddDmxMapping.tsx
@@ -58,11 +58,10 @@ export default function DialogAddDmxMapping({ integrationId, editMapping, editIn
   const [rCh, setRCh] = useState(1)
   const [gCh, setGCh] = useState(2)
   const [bCh, setBCh] = useState(3)
-  const [modeCh, setModeCh] = useState(1)
-  const [dimmerCh, setDimmerCh] = useState(2)
-  const [fxRCh, setFxRCh] = useState(3)
-  const [fxGCh, setFxGCh] = useState(4)
-  const [fxBCh, setFxBCh] = useState(5)
+  const [dimmerCh, setDimmerCh] = useState(1)
+  const [fxRCh, setFxRCh] = useState(2)
+  const [fxGCh, setFxGCh] = useState(3)
+  const [fxBCh, setFxBCh] = useState(4)
 
   // target
   const [venueId, setVenueId] = useState('')
@@ -86,11 +85,10 @@ export default function DialogAddDmxMapping({ integrationId, editMapping, editIn
       setBCh(Array.isArray(ch) ? (ch[2] ?? 3) : 3)
     } else if (m.type === 'fixture') {
       const d = !Array.isArray(ch) ? ch : {}
-      setModeCh(d.mode ?? (Array.isArray(ch) ? ch[0] : 1) ?? 1)
-      setDimmerCh(d.dimmer ?? (Array.isArray(ch) ? ch[1] : 2) ?? 2)
-      setFxRCh(d.r ?? (Array.isArray(ch) ? ch[2] : 3) ?? 3)
-      setFxGCh(d.g ?? (Array.isArray(ch) ? ch[3] : 4) ?? 4)
-      setFxBCh(d.b ?? (Array.isArray(ch) ? ch[4] : 5) ?? 5)
+      setDimmerCh(d.dimmer ?? (Array.isArray(ch) ? ch[0] : 1) ?? 1)
+      setFxRCh(d.r ?? (Array.isArray(ch) ? ch[1] : 2) ?? 2)
+      setFxGCh(d.g ?? (Array.isArray(ch) ? ch[2] : 3) ?? 3)
+      setFxBCh(d.b ?? (Array.isArray(ch) ? ch[3] : 4) ?? 4)
     }
     if (m.virtual_id) {
       setTargetKind('virtual')
@@ -161,14 +159,11 @@ export default function DialogAddDmxMapping({ integrationId, editMapping, editIn
       }
     } else if (type === 'fixture') {
       m.channels = {
-        mode: Number(modeCh),
         dimmer: Number(dimmerCh),
         r: Number(fxRCh),
         g: Number(fxGCh),
         b: Number(fxBCh)
       }
-      m.on_threshold = Number(onThreshold)
-      m.off_threshold = Number(offThreshold)
       m.virtual_id = virtualId
     }
     return m
@@ -264,7 +259,6 @@ export default function DialogAddDmxMapping({ integrationId, editMapping, editIn
               )}
               {type === 'fixture' && (
                 <Stack direction="row" spacing={2} flexWrap="wrap" useFlexGap>
-                  {channelField('Mode ch', modeCh, setModeCh)}
                   {channelField('Dimmer ch', dimmerCh, setDimmerCh)}
                   {channelField('Red ch', fxRCh, setFxRCh)}
                   {channelField('Green ch', fxGCh, setFxGCh)}
@@ -273,8 +267,8 @@ export default function DialogAddDmxMapping({ integrationId, editMapping, editIn
               )}
             </Box>
 
-            {/* Thresholds (trigger + fixture mode toggle) */}
-            {(type === 'trigger' || type === 'fixture') && (
+            {/* Thresholds (trigger button press only; fixture wash has no gate) */}
+            {type === 'trigger' && (
               <Stack direction="row" spacing={2}>
                 <TextField
                   label="On threshold"

--- a/src/components/Integrations/DmxInput/DialogAddDmxMapping.tsx
+++ b/src/components/Integrations/DmxInput/DialogAddDmxMapping.tsx
@@ -1,0 +1,397 @@
+import React, { useEffect, useMemo, useState } from 'react'
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  TextField,
+  MenuItem,
+  Stack,
+  Switch,
+  FormControlLabel,
+  Box,
+  Typography,
+  IconButton
+} from '@mui/material'
+import { Add, Edit } from '@mui/icons-material'
+import useStore from '../../../store/useStore'
+import type { DmxMapping } from '../../../store/ui/storeDmxInput'
+
+interface Props {
+  integrationId: string
+  editMapping?: DmxMapping
+  editIndex?: number
+}
+
+type TargetKind = 'venue' | 'virtual'
+
+const defaultMapping = (): DmxMapping => ({
+  name: '',
+  type: 'trigger',
+  universe: 0,
+  channels: [1],
+  on_threshold: 128,
+  off_threshold: 96,
+  active: true
+})
+
+export default function DialogAddDmxMapping({ integrationId, editMapping, editIndex }: Props) {
+  const isEdit = editMapping !== undefined && editIndex !== undefined
+  const dmxData = useStore((state) => state.dmxInput[integrationId])
+  const saveDmxMapping = useStore((state) => state.saveDmxMapping)
+  const getDmxInput = useStore((state) => state.getDmxInput)
+
+  const venues = useMemo(() => dmxData?.venues || {}, [dmxData])
+  const virtuals = useMemo(() => dmxData?.virtuals || {}, [dmxData])
+
+  const [open, setOpen] = useState(false)
+  const [name, setName] = useState('')
+  const [type, setType] = useState<DmxMapping['type']>('trigger')
+  const [universe, setUniverse] = useState(0)
+  const [active, setActive] = useState(true)
+  const [onThreshold, setOnThreshold] = useState(128)
+  const [offThreshold, setOffThreshold] = useState(96)
+
+  // channels
+  const [triggerCh, setTriggerCh] = useState(1)
+  const [rCh, setRCh] = useState(1)
+  const [gCh, setGCh] = useState(2)
+  const [bCh, setBCh] = useState(3)
+  const [modeCh, setModeCh] = useState(1)
+  const [dimmerCh, setDimmerCh] = useState(2)
+  const [fxRCh, setFxRCh] = useState(3)
+  const [fxGCh, setFxGCh] = useState(4)
+  const [fxBCh, setFxBCh] = useState(5)
+
+  // target
+  const [venueId, setVenueId] = useState('')
+  const [padIndex, setPadIndex] = useState(0)
+  const [virtualId, setVirtualId] = useState('')
+  const [targetKind, setTargetKind] = useState<TargetKind>('venue')
+
+  const resetFromMapping = (m: DmxMapping) => {
+    setName(m.name || '')
+    setType(m.type)
+    setUniverse(m.universe ?? 0)
+    setActive(m.active ?? true)
+    setOnThreshold(m.on_threshold ?? 128)
+    setOffThreshold(m.off_threshold ?? 96)
+    const ch: any = m.channels
+    if (m.type === 'trigger') {
+      setTriggerCh(Array.isArray(ch) ? (ch[0] ?? 1) : 1)
+    } else if (m.type === 'color') {
+      setRCh(Array.isArray(ch) ? (ch[0] ?? 1) : 1)
+      setGCh(Array.isArray(ch) ? (ch[1] ?? 2) : 2)
+      setBCh(Array.isArray(ch) ? (ch[2] ?? 3) : 3)
+    } else if (m.type === 'fixture') {
+      const d = !Array.isArray(ch) ? ch : {}
+      setModeCh(d.mode ?? (Array.isArray(ch) ? ch[0] : 1) ?? 1)
+      setDimmerCh(d.dimmer ?? (Array.isArray(ch) ? ch[1] : 2) ?? 2)
+      setFxRCh(d.r ?? (Array.isArray(ch) ? ch[2] : 3) ?? 3)
+      setFxGCh(d.g ?? (Array.isArray(ch) ? ch[3] : 4) ?? 4)
+      setFxBCh(d.b ?? (Array.isArray(ch) ? ch[4] : 5) ?? 5)
+    }
+    if (m.virtual_id) {
+      setTargetKind('virtual')
+      setVirtualId(m.virtual_id)
+    } else if (m.venue_id) {
+      setTargetKind('venue')
+      setVenueId(m.venue_id)
+      setPadIndex(m.pad_index ?? 0)
+    }
+  }
+
+  const handleOpen = () => {
+    if (isEdit && editMapping) {
+      resetFromMapping(editMapping)
+    } else {
+      const d = defaultMapping()
+      resetFromMapping(d)
+      setVenueId(Object.keys(venues)[0] || '')
+      setVirtualId('')
+    }
+    setOpen(true)
+  }
+
+  const handleClose = () => setOpen(false)
+
+  // keep venue default sensible when venues load
+  useEffect(() => {
+    if (open && !isEdit && !venueId && Object.keys(venues).length) {
+      setVenueId(Object.keys(venues)[0])
+    }
+  }, [open, isEdit, venueId, venues])
+
+  // default a virtual target so fixture / color-virtual mappings are never empty
+  useEffect(() => {
+    if (!open || isEdit) return
+    const needsVirtual = type === 'fixture' || (type === 'color' && targetKind === 'virtual')
+    if (needsVirtual && !virtualId && Object.keys(virtuals).length) {
+      setVirtualId(Object.keys(virtuals)[0])
+    }
+  }, [open, isEdit, type, targetKind, virtualId, virtuals])
+
+  const targetValid = (() => {
+    if (type === 'trigger') return !!venueId
+    if (type === 'color') return targetKind === 'virtual' ? !!virtualId : !!venueId
+    return !!virtualId
+  })()
+
+  const buildMapping = (): DmxMapping => {
+    const m: DmxMapping = {
+      name: name || undefined,
+      type,
+      universe: Number(universe),
+      channels: [1],
+      active
+    }
+    if (type === 'trigger') {
+      m.channels = [Number(triggerCh)]
+      m.on_threshold = Number(onThreshold)
+      m.off_threshold = Number(offThreshold)
+      m.venue_id = venueId
+      m.pad_index = Number(padIndex)
+    } else if (type === 'color') {
+      m.channels = [Number(rCh), Number(gCh), Number(bCh)]
+      if (targetKind === 'virtual') {
+        m.virtual_id = virtualId
+      } else {
+        m.venue_id = venueId
+      }
+    } else if (type === 'fixture') {
+      m.channels = {
+        mode: Number(modeCh),
+        dimmer: Number(dimmerCh),
+        r: Number(fxRCh),
+        g: Number(fxGCh),
+        b: Number(fxBCh)
+      }
+      m.on_threshold = Number(onThreshold)
+      m.off_threshold = Number(offThreshold)
+      m.virtual_id = virtualId
+    }
+    return m
+  }
+
+  const handleSave = async () => {
+    const mapping = buildMapping()
+    await saveDmxMapping(integrationId, mapping, isEdit ? editIndex : undefined)
+    await getDmxInput(integrationId)
+    setOpen(false)
+  }
+
+  const venuePads = venueId && venues[venueId] ? venues[venueId]?.color_pads?.pads || [] : []
+
+  const channelField = (lbl: string, val: number, setter: (n: number) => void) => (
+    <TextField
+      label={lbl}
+      type="number"
+      size="small"
+      value={val}
+      onChange={(e) => setter(Number(e.target.value))}
+      inputProps={{ min: 1, max: 512 }}
+      sx={{ width: 110 }}
+    />
+  )
+
+  return (
+    <>
+      {isEdit ? (
+        <IconButton aria-label="Edit" color="inherit" onClick={handleOpen}>
+          <Edit fontSize="inherit" />
+        </IconButton>
+      ) : (
+        <Button variant="contained" color="primary" startIcon={<Add />} onClick={handleOpen}>
+          Add Mapping
+        </Button>
+      )}
+      <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
+        <DialogTitle>{isEdit ? 'Edit DMX Mapping' : 'Add DMX Mapping'}</DialogTitle>
+        <DialogContent>
+          <Stack spacing={2} sx={{ mt: 1 }}>
+            <TextField
+              label="Name"
+              size="small"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              fullWidth
+            />
+            <Stack direction="row" spacing={2}>
+              <TextField
+                select
+                label="Type"
+                size="small"
+                value={type}
+                onChange={(e) => setType(e.target.value as DmxMapping['type'])}
+                sx={{ width: 160 }}
+              >
+                <MenuItem value="trigger">Trigger (button)</MenuItem>
+                <MenuItem value="color">Color (live RGB)</MenuItem>
+                <MenuItem value="fixture">Fixture (wash)</MenuItem>
+              </TextField>
+              <TextField
+                label="Universe"
+                type="number"
+                size="small"
+                value={universe}
+                onChange={(e) => setUniverse(Number(e.target.value))}
+                inputProps={{ min: 0, max: 32767 }}
+                sx={{ width: 120 }}
+              />
+              <FormControlLabel
+                control={<Switch checked={active} onChange={(e) => setActive(e.target.checked)} />}
+                label="Active"
+              />
+            </Stack>
+
+            {/* Channels */}
+            <Box>
+              <Typography variant="subtitle2" sx={{ mb: 1 }}>
+                Channels
+              </Typography>
+              {type === 'trigger' && (
+                <Stack direction="row" spacing={2}>
+                  {channelField('Button ch', triggerCh, setTriggerCh)}
+                </Stack>
+              )}
+              {type === 'color' && (
+                <Stack direction="row" spacing={2}>
+                  {channelField('Red ch', rCh, setRCh)}
+                  {channelField('Green ch', gCh, setGCh)}
+                  {channelField('Blue ch', bCh, setBCh)}
+                </Stack>
+              )}
+              {type === 'fixture' && (
+                <Stack direction="row" spacing={2} flexWrap="wrap" useFlexGap>
+                  {channelField('Mode ch', modeCh, setModeCh)}
+                  {channelField('Dimmer ch', dimmerCh, setDimmerCh)}
+                  {channelField('Red ch', fxRCh, setFxRCh)}
+                  {channelField('Green ch', fxGCh, setFxGCh)}
+                  {channelField('Blue ch', fxBCh, setFxBCh)}
+                </Stack>
+              )}
+            </Box>
+
+            {/* Thresholds (trigger + fixture mode toggle) */}
+            {(type === 'trigger' || type === 'fixture') && (
+              <Stack direction="row" spacing={2}>
+                <TextField
+                  label="On threshold"
+                  type="number"
+                  size="small"
+                  value={onThreshold}
+                  onChange={(e) => setOnThreshold(Number(e.target.value))}
+                  inputProps={{ min: 0, max: 255 }}
+                  sx={{ width: 140 }}
+                />
+                <TextField
+                  label="Off threshold"
+                  type="number"
+                  size="small"
+                  value={offThreshold}
+                  onChange={(e) => setOffThreshold(Number(e.target.value))}
+                  inputProps={{ min: 0, max: 255 }}
+                  sx={{ width: 140 }}
+                />
+              </Stack>
+            )}
+
+            {/* Target */}
+            <Box>
+              <Typography variant="subtitle2" sx={{ mb: 1 }}>
+                Target
+              </Typography>
+              {type === 'color' && (
+                <TextField
+                  select
+                  label="Target type"
+                  size="small"
+                  value={targetKind}
+                  onChange={(e) => setTargetKind(e.target.value as TargetKind)}
+                  sx={{ width: 160, mb: 2 }}
+                >
+                  <MenuItem value="venue">Venue</MenuItem>
+                  <MenuItem value="virtual">Virtual</MenuItem>
+                </TextField>
+              )}
+
+              {(type === 'trigger' || (type === 'color' && targetKind === 'venue')) && (
+                <Stack direction="row" spacing={2}>
+                  <TextField
+                    select
+                    label="Venue"
+                    size="small"
+                    value={venueId}
+                    onChange={(e) => {
+                      setVenueId(e.target.value)
+                      setPadIndex(0)
+                    }}
+                    sx={{ minWidth: 180 }}
+                  >
+                    {Object.keys(venues).map((vid) => (
+                      <MenuItem key={vid} value={vid}>
+                        {venues[vid]?.name || vid}
+                      </MenuItem>
+                    ))}
+                  </TextField>
+                  {type === 'trigger' && (
+                    <TextField
+                      select
+                      label="Pad"
+                      size="small"
+                      value={padIndex}
+                      onChange={(e) => setPadIndex(Number(e.target.value))}
+                      sx={{ minWidth: 160 }}
+                    >
+                      {venuePads.map((pad: any, i: number) => (
+                        <MenuItem key={i} value={i}>
+                          <Box
+                            component="span"
+                            sx={{
+                              display: 'inline-block',
+                              width: 16,
+                              height: 16,
+                              borderRadius: '3px',
+                              mr: 1,
+                              verticalAlign: 'middle',
+                              background: pad.gradient || pad.color || '#000'
+                            }}
+                          />
+                          Pad {i + 1}
+                        </MenuItem>
+                      ))}
+                    </TextField>
+                  )}
+                </Stack>
+              )}
+
+              {(type === 'fixture' || (type === 'color' && targetKind === 'virtual')) && (
+                <TextField
+                  select
+                  label="Virtual"
+                  size="small"
+                  value={virtualId}
+                  onChange={(e) => setVirtualId(e.target.value)}
+                  sx={{ minWidth: 240 }}
+                >
+                  {Object.keys(virtuals).map((vid) => (
+                    <MenuItem key={vid} value={vid}>
+                      {virtuals[vid]}
+                    </MenuItem>
+                  ))}
+                </TextField>
+              )}
+            </Box>
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleClose}>Cancel</Button>
+          <Button onClick={handleSave} variant="contained" color="primary" disabled={!targetValid}>
+            Save
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  )
+}

--- a/src/components/Integrations/DmxInput/DialogAddDmxMapping.tsx
+++ b/src/components/Integrations/DmxInput/DialogAddDmxMapping.tsx
@@ -12,7 +12,8 @@ import {
   FormControlLabel,
   Box,
   Typography,
-  IconButton
+  IconButton,
+  Slider
 } from '@mui/material'
 import { Add, Edit } from '@mui/icons-material'
 import useStore from '../../../store/useStore'
@@ -62,6 +63,15 @@ export default function DialogAddDmxMapping({ integrationId, editMapping, editIn
   const [fxRCh, setFxRCh] = useState(2)
   const [fxGCh, setFxGCh] = useState(3)
   const [fxBCh, setFxBCh] = useState(4)
+  // Fixture wash only: 0 = every strobe pulse renders (default, today's
+  // exact behaviour), 100 = pulses fire with real-fixture-like randomness.
+  // Stored/sent to the backend inverted, as strobe_probability = 1 - x/100.
+  const [strobeRandomness, setStrobeRandomness] = useState(0)
+
+  // Per-type last-entered field values, so switching a mapping's type in
+  // this dialog (or across dialog sessions, once saved) re-populates each
+  // type's previous fields instead of resetting to schema defaults.
+  const [typeFieldCache, setTypeFieldCache] = useState<Record<string, Record<string, unknown>>>({})
 
   // target
   const [venueId, setVenueId] = useState('')
@@ -89,6 +99,8 @@ export default function DialogAddDmxMapping({ integrationId, editMapping, editIn
       setFxRCh(d.r ?? (Array.isArray(ch) ? ch[1] : 2) ?? 2)
       setFxGCh(d.g ?? (Array.isArray(ch) ? ch[2] : 3) ?? 3)
       setFxBCh(d.b ?? (Array.isArray(ch) ? ch[3] : 4) ?? 4)
+      const sp = m.strobe_probability ?? 1
+      setStrobeRandomness(Math.round((1 - sp) * 100))
     }
     if (m.virtual_id) {
       setTargetKind('virtual')
@@ -98,6 +110,69 @@ export default function DialogAddDmxMapping({ integrationId, editMapping, editIn
       setVenueId(m.venue_id)
       setPadIndex(m.pad_index ?? 0)
     }
+    setTypeFieldCache(m._type_field_cache || {})
+  }
+
+  // Snapshot of the fields currently entered for a given mapping type, used
+  // both to persist the per-type cache and to restore it on type switch.
+  const captureCurrentTypeFields = (t: DmxMapping['type']): Record<string, unknown> => {
+    if (t === 'trigger') {
+      return {
+        channels: [triggerCh],
+        on_threshold: onThreshold,
+        off_threshold: offThreshold,
+        venue_id: venueId,
+        pad_index: padIndex
+      }
+    }
+    if (t === 'color') {
+      return {
+        channels: [rCh, gCh, bCh],
+        target_kind: targetKind,
+        venue_id: venueId,
+        virtual_id: virtualId
+      }
+    }
+    return {
+      channels: { dimmer: dimmerCh, r: fxRCh, g: fxGCh, b: fxBCh },
+      virtual_id: virtualId,
+      strobe_probability: 1 - strobeRandomness / 100
+    }
+  }
+
+  const applyCachedTypeFields = (t: DmxMapping['type'], cached?: Record<string, unknown>) => {
+    if (!cached) return
+    const ch: any = cached.channels
+    if (t === 'trigger') {
+      setTriggerCh(Array.isArray(ch) ? (ch[0] ?? 1) : 1)
+      setOnThreshold((cached.on_threshold as number) ?? 128)
+      setOffThreshold((cached.off_threshold as number) ?? 96)
+      if (cached.venue_id) setVenueId(cached.venue_id as string)
+      if (cached.pad_index !== undefined) setPadIndex(cached.pad_index as number)
+    } else if (t === 'color') {
+      setRCh(Array.isArray(ch) ? (ch[0] ?? 1) : 1)
+      setGCh(Array.isArray(ch) ? (ch[1] ?? 2) : 2)
+      setBCh(Array.isArray(ch) ? (ch[2] ?? 3) : 3)
+      if (cached.target_kind) setTargetKind(cached.target_kind as TargetKind)
+      if (cached.venue_id) setVenueId(cached.venue_id as string)
+      if (cached.virtual_id) setVirtualId(cached.virtual_id as string)
+    } else {
+      const d = !Array.isArray(ch) ? (ch as Record<string, number>) : {}
+      setDimmerCh(d.dimmer ?? 1)
+      setFxRCh(d.r ?? 2)
+      setFxGCh(d.g ?? 3)
+      setFxBCh(d.b ?? 4)
+      if (cached.virtual_id) setVirtualId(cached.virtual_id as string)
+      const sp = (cached.strobe_probability as number) ?? 1
+      setStrobeRandomness(Math.round((1 - sp) * 100))
+    }
+  }
+
+  const handleTypeChange = (newType: DmxMapping['type']) => {
+    const nextCache = { ...typeFieldCache, [type]: captureCurrentTypeFields(type) }
+    setTypeFieldCache(nextCache)
+    applyCachedTypeFields(newType, nextCache[newType])
+    setType(newType)
   }
 
   const handleOpen = () => {
@@ -165,7 +240,9 @@ export default function DialogAddDmxMapping({ integrationId, editMapping, editIn
         b: Number(fxBCh)
       }
       m.virtual_id = virtualId
+      m.strobe_probability = Number((1 - strobeRandomness / 100).toFixed(2))
     }
+    m._type_field_cache = { ...typeFieldCache, [type]: captureCurrentTypeFields(type) }
     return m
   }
 
@@ -218,7 +295,7 @@ export default function DialogAddDmxMapping({ integrationId, editMapping, editIn
                 label="Type"
                 size="small"
                 value={type}
-                onChange={(e) => setType(e.target.value as DmxMapping['type'])}
+                onChange={(e) => handleTypeChange(e.target.value as DmxMapping['type'])}
                 sx={{ width: 160 }}
               >
                 <MenuItem value="trigger">Trigger (button)</MenuItem>
@@ -266,6 +343,34 @@ export default function DialogAddDmxMapping({ integrationId, editMapping, editIn
                 </Stack>
               )}
             </Box>
+
+            {/* Strobe randomness (fixture wash only): real fixtures each run
+                their own oscillator so multiple fixtures visibly drift out
+                of sync -- LedFx mirrors the dimmer frame-perfectly by
+                default, which can look artificially "locked" next to real
+                fixtures. Raising this makes each detected strobe pulse have
+                a chance to be suppressed instead of always firing. */}
+            {type === 'fixture' && (
+              <Box>
+                <Typography variant="subtitle2" sx={{ mb: 1 }}>
+                  Strobe randomness: {strobeRandomness}%
+                </Typography>
+                <Slider
+                  aria-label="Strobe randomness"
+                  value={strobeRandomness}
+                  onChange={(_e, v) => setStrobeRandomness(v as number)}
+                  step={5}
+                  min={0}
+                  max={100}
+                  marks={[
+                    { value: 0, label: '0% (off)' },
+                    { value: 100, label: '100%' }
+                  ]}
+                  valueLabelDisplay="auto"
+                  sx={{ maxWidth: 360 }}
+                />
+              </Box>
+            )}
 
             {/* Thresholds (trigger button press only; fixture wash has no gate) */}
             {type === 'trigger' && (

--- a/src/components/Integrations/DmxInput/DmxLiveMonitor.tsx
+++ b/src/components/Integrations/DmxInput/DmxLiveMonitor.tsx
@@ -1,0 +1,201 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import {
+  Box,
+  Typography,
+  Button,
+  Stack,
+  Paper,
+  Tooltip,
+  Chip,
+  Accordion,
+  AccordionSummary,
+  AccordionDetails
+} from '@mui/material'
+import { ExpandMore, Sensors } from '@mui/icons-material'
+import useStore from '../../../store/useStore'
+
+interface Props {
+  integrationId: string
+  open: boolean
+}
+
+const POLL_MS = 200
+const CHANNELS_SHOWN = 64
+
+export default function DmxLiveMonitor({ integrationId, open }: Props) {
+  const getDmxLive = useStore((state) => state.getDmxLive)
+  const liveDmxRaw = useStore((state) => state.dmxInput[integrationId]?.live_dmx)
+  const liveDmx = useMemo(() => liveDmxRaw || {}, [liveDmxRaw])
+
+  const [polling, setPolling] = useState(false)
+  const [learn, setLearn] = useState(false)
+  const [learned, setLearned] = useState<{ universe: string; channel: number } | null>(null)
+  const baselineRef = useRef<Record<string, number[]>>({})
+  const intervalRef = useRef<any>(null)
+  const inFlightRef = useRef(false)
+
+  useEffect(() => {
+    if (open && polling) {
+      intervalRef.current = setInterval(() => {
+        if (inFlightRef.current) return
+        inFlightRef.current = true
+        Promise.resolve(getDmxLive(integrationId)).finally(() => {
+          inFlightRef.current = false
+        })
+      }, POLL_MS)
+    }
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current)
+        intervalRef.current = null
+      }
+    }
+  }, [open, polling, integrationId, getDmxLive])
+
+  // stop polling when the screen closes
+  useEffect(() => {
+    if (!open) {
+      setPolling(false)
+      setLearn(false)
+    }
+  }, [open])
+
+  // learn: find the channel with the biggest jump from the captured baseline
+  useEffect(() => {
+    if (!learn || learned) return
+    let best: { universe: string; channel: number; delta: number } | null = null
+    Object.keys(liveDmx).forEach((u) => {
+      const cur = liveDmx[u] || []
+      const base = baselineRef.current[u] || []
+      cur.forEach((val, idx) => {
+        const delta = Math.abs(val - (base[idx] ?? 0))
+        if (delta > 40 && (!best || delta > best.delta)) {
+          best = { universe: u, channel: idx + 1, delta }
+        }
+      })
+    })
+    if (best) {
+      setLearned({ universe: (best as any).universe, channel: (best as any).channel })
+    }
+  }, [liveDmx, learn, learned])
+
+  const startLearn = () => {
+    // snapshot current values as baseline
+    const snap: Record<string, number[]> = {}
+    Object.keys(liveDmx).forEach((u) => {
+      snap[u] = [...(liveDmx[u] || [])]
+    })
+    baselineRef.current = snap
+    setLearned(null)
+    setLearn(true)
+    setPolling(true)
+  }
+
+  const cellColor = (val: number) => {
+    if (val === 0) return 'transparent'
+    const a = Math.max(0.15, val / 255)
+    return `rgba(33, 150, 243, ${a})`
+  }
+
+  const universes = Object.keys(liveDmx)
+
+  return (
+    <Accordion defaultExpanded>
+      <AccordionSummary expandIcon={<ExpandMore />}>
+        <Stack direction="row" spacing={1} alignItems="center">
+          <Sensors fontSize="small" />
+          <Typography>Live DMX monitor &amp; channel learn</Typography>
+        </Stack>
+      </AccordionSummary>
+      <AccordionDetails>
+        <Stack direction="row" spacing={2} alignItems="center" sx={{ mb: 2 }} flexWrap="wrap">
+          <Button
+            variant={polling ? 'contained' : 'outlined'}
+            color="primary"
+            onClick={() => setPolling((p) => !p)}
+          >
+            {polling ? 'Stop monitor' : 'Start monitor'}
+          </Button>
+          <Button
+            variant="outlined"
+            color="secondary"
+            onClick={startLearn}
+            disabled={!universes.length}
+          >
+            Learn channel
+          </Button>
+          {learn && !learned && (
+            <Typography variant="body2" sx={{ opacity: 0.7 }}>
+              Press the SoundSwitch button / move the fader now…
+            </Typography>
+          )}
+          {learned && (
+            <Chip
+              color="success"
+              label={`Detected: universe ${learned.universe}, channel ${learned.channel}`}
+              onDelete={() => {
+                setLearn(false)
+                setLearned(null)
+              }}
+            />
+          )}
+        </Stack>
+
+        {!universes.length && (
+          <Typography variant="body2" sx={{ opacity: 0.6 }}>
+            No DMX received yet. Start the monitor and make sure SoundSwitch is sending Art-Net to
+            this machine.
+          </Typography>
+        )}
+
+        {universes.map((u) => {
+          const vals = liveDmx[u] || []
+          return (
+            <Box key={u} sx={{ mb: 2 }}>
+              <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
+                Universe {u}
+              </Typography>
+              <Paper variant="outlined" sx={{ p: 1 }}>
+                <Box
+                  sx={{
+                    display: 'grid',
+                    gridTemplateColumns: 'repeat(16, 1fr)',
+                    gap: '2px'
+                  }}
+                >
+                  {Array.from({
+                    length: Math.min(CHANNELS_SHOWN, vals.length || CHANNELS_SHOWN)
+                  }).map((_, i) => {
+                    const val = vals[i] ?? 0
+                    const isLearned = learned && learned.universe === u && learned.channel === i + 1
+                    return (
+                      <Tooltip key={i} title={`Ch ${i + 1}: ${val}`} arrow>
+                        <Box
+                          sx={{
+                            height: 26,
+                            borderRadius: '3px',
+                            border: isLearned
+                              ? '2px solid #66bb6a'
+                              : '1px solid rgba(255,255,255,0.12)',
+                            background: cellColor(val),
+                            fontSize: 9,
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            color: val > 140 ? '#fff' : 'inherit'
+                          }}
+                        >
+                          {val > 0 ? val : i + 1}
+                        </Box>
+                      </Tooltip>
+                    )
+                  })}
+                </Box>
+              </Paper>
+            </Box>
+          )
+        })}
+      </AccordionDetails>
+    </Accordion>
+  )
+}

--- a/src/components/Integrations/DmxInput/DmxMappingTable.tsx
+++ b/src/components/Integrations/DmxInput/DmxMappingTable.tsx
@@ -28,7 +28,7 @@ const channelSummary = (m: DmxMapping): string => {
     return Array.isArray(ch) ? `R${ch[0]} G${ch[1]} B${ch[2]}` : ''
   }
   if (m.type === 'fixture' && !Array.isArray(ch)) {
-    return `M${ch.mode} D${ch.dimmer} R${ch.r} G${ch.g} B${ch.b}`
+    return `D${ch.dimmer} R${ch.r} G${ch.g} B${ch.b}`
   }
   return JSON.stringify(ch)
 }
@@ -99,9 +99,7 @@ export default function DmxMappingTable({ integrationId }: Props) {
               <TableCell>{channelSummary(m)}</TableCell>
               <TableCell>{targetSummary(m)}</TableCell>
               <TableCell>
-                {m.type === 'trigger' || m.type === 'fixture'
-                  ? `${m.on_threshold ?? 128} / ${m.off_threshold ?? 96}`
-                  : '—'}
+                {m.type === 'trigger' ? `${m.on_threshold ?? 128} / ${m.off_threshold ?? 96}` : '—'}
               </TableCell>
               <TableCell>{m.active === false ? 'No' : 'Yes'}</TableCell>
               <TableCell align="right">

--- a/src/components/Integrations/DmxInput/DmxMappingTable.tsx
+++ b/src/components/Integrations/DmxInput/DmxMappingTable.tsx
@@ -1,0 +1,128 @@
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+  Chip,
+  Box,
+  Typography
+} from '@mui/material'
+import useStore from '../../../store/useStore'
+import Popover from '../../Popover/Popover'
+import DialogAddDmxMapping from './DialogAddDmxMapping'
+import type { DmxMapping } from '../../../store/ui/storeDmxInput'
+
+interface Props {
+  integrationId: string
+}
+
+const channelSummary = (m: DmxMapping): string => {
+  const ch: any = m.channels
+  if (m.type === 'trigger') {
+    return `ch ${Array.isArray(ch) ? ch[0] : ch}`
+  }
+  if (m.type === 'color') {
+    return Array.isArray(ch) ? `R${ch[0]} G${ch[1]} B${ch[2]}` : ''
+  }
+  if (m.type === 'fixture' && !Array.isArray(ch)) {
+    return `M${ch.mode} D${ch.dimmer} R${ch.r} G${ch.g} B${ch.b}`
+  }
+  return JSON.stringify(ch)
+}
+
+const typeColor: Record<string, any> = {
+  trigger: 'primary',
+  color: 'secondary',
+  fixture: 'warning'
+}
+
+export default function DmxMappingTable({ integrationId }: Props) {
+  const dmxData = useStore((state) => state.dmxInput[integrationId])
+  const deleteDmxMapping = useStore((state) => state.deleteDmxMapping)
+  const getDmxInput = useStore((state) => state.getDmxInput)
+
+  const mappings = dmxData?.mappings || []
+  const venues = dmxData?.venues || {}
+  const virtuals = dmxData?.virtuals || {}
+
+  const targetSummary = (m: DmxMapping): string => {
+    if (m.virtual_id) {
+      return `Virtual: ${virtuals[m.virtual_id] || m.virtual_id}`
+    }
+    if (m.venue_id) {
+      const vname = venues[m.venue_id]?.name || m.venue_id
+      return m.pad_index !== undefined && m.pad_index !== null
+        ? `${vname} · Pad ${m.pad_index + 1}`
+        : `Venue: ${vname}`
+    }
+    return '—'
+  }
+
+  const handleDelete = (index: number) => {
+    deleteDmxMapping(integrationId, index).then(() => getDmxInput(integrationId))
+  }
+
+  if (!mappings.length) {
+    return (
+      <Box sx={{ p: 2, textAlign: 'center', opacity: 0.6 }}>
+        <Typography>No mappings yet. Add one to bridge a DMX channel to LedFx.</Typography>
+      </Box>
+    )
+  }
+
+  return (
+    <TableContainer component={Paper} sx={{ boxShadow: 2 }}>
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell>Name</TableCell>
+            <TableCell>Type</TableCell>
+            <TableCell>Universe</TableCell>
+            <TableCell>Channels</TableCell>
+            <TableCell>Target</TableCell>
+            <TableCell>Thresholds</TableCell>
+            <TableCell>Active</TableCell>
+            <TableCell align="right">Actions</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {mappings.map((m, i) => (
+            <TableRow key={i}>
+              <TableCell>{m.name || `Mapping ${i + 1}`}</TableCell>
+              <TableCell>
+                <Chip label={m.type} size="small" color={typeColor[m.type] || 'default'} />
+              </TableCell>
+              <TableCell>{m.universe}</TableCell>
+              <TableCell>{channelSummary(m)}</TableCell>
+              <TableCell>{targetSummary(m)}</TableCell>
+              <TableCell>
+                {m.type === 'trigger' || m.type === 'fixture'
+                  ? `${m.on_threshold ?? 128} / ${m.off_threshold ?? 96}`
+                  : '—'}
+              </TableCell>
+              <TableCell>{m.active === false ? 'No' : 'Yes'}</TableCell>
+              <TableCell align="right">
+                <Box sx={{ display: 'flex', justifyContent: 'flex-end', alignItems: 'center' }}>
+                  <DialogAddDmxMapping
+                    integrationId={integrationId}
+                    editMapping={m}
+                    editIndex={i}
+                  />
+                  <Popover
+                    variant="text"
+                    color="inherit"
+                    style={{ minWidth: 40 }}
+                    onConfirm={() => handleDelete(i)}
+                  />
+                </Box>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  )
+}

--- a/src/pages/Integrations/DmxInput/DmxInputScreen/DmxInputScreen.props.tsx
+++ b/src/pages/Integrations/DmxInput/DmxInputScreen/DmxInputScreen.props.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import { Settings } from '@mui/icons-material'
+import { TransitionProps } from '@mui/material/transitions'
+import { MenuItem, Slide } from '@mui/material'
+
+export interface DmxInputScreenProps {
+  integrationId: string
+  icon?: React.ReactElement<any>
+  startIcon?: React.ReactElement<any>
+  label?: string
+  type?: string
+  className?: string
+  color?: 'inherit' | 'primary' | 'secondary' | 'error' | 'success' | 'warning' | 'info' | undefined
+  variant?: 'outlined' | 'text' | 'contained' | undefined
+  innerKey?: string
+  disabled?: boolean
+  size?: 'small' | 'medium' | 'large' | undefined
+}
+
+export const Transition = React.forwardRef(function Transition(
+  props: TransitionProps & { children?: React.ReactElement<any> } = {
+    children: <div>loading</div>
+  },
+  ref: React.Ref<unknown>
+) {
+  return <Slide direction="up" ref={ref} {...(props as any)} />
+})
+
+export const MuiMenuItem = React.forwardRef((props: any, ref: React.Ref<unknown>) => {
+  return <MenuItem ref={ref} {...props} />
+})
+
+export { Settings }

--- a/src/pages/Integrations/DmxInput/DmxInputScreen/DmxInputScreen.tsx
+++ b/src/pages/Integrations/DmxInput/DmxInputScreen/DmxInputScreen.tsx
@@ -1,0 +1,112 @@
+import React, { useEffect } from 'react'
+import { Typography, Toolbar, AppBar, Dialog, Button, Box } from '@mui/material'
+import { Settings, NavigateBefore } from '@mui/icons-material'
+import isElectron from 'is-electron'
+import { DmxInputScreenProps, MuiMenuItem, Transition } from './DmxInputScreen.props'
+import useEditVirtualsStyles from '../../../Devices/EditVirtuals/EditVirtuals.styles'
+import useStore from '../../../../store/useStore'
+import DmxMappingTable from '../../../../components/Integrations/DmxInput/DmxMappingTable'
+import DialogAddDmxMapping from '../../../../components/Integrations/DmxInput/DialogAddDmxMapping'
+import DmxLiveMonitor from '../../../../components/Integrations/DmxInput/DmxLiveMonitor'
+
+export default function DmxInputScreen({
+  integrationId,
+  icon = <Settings />,
+  startIcon,
+  label = '',
+  type,
+  className,
+  color = 'primary',
+  variant = 'contained',
+  innerKey,
+  disabled = false,
+  size = 'small'
+}: DmxInputScreenProps) {
+  const classes = useEditVirtualsStyles()
+  const [open, setOpen] = React.useState(false)
+  const platform = useStore((state) => state.platform)
+  const getDmxInput = useStore((state) => state.getDmxInput)
+
+  const handleClickOpen = () => setOpen(true)
+  const handleClose = () => setOpen(false)
+
+  useEffect(() => {
+    if (open && integrationId) {
+      getDmxInput(integrationId)
+    }
+  }, [open, integrationId, getDmxInput])
+
+  return (
+    <>
+      {type === 'menuItem' ? (
+        <MuiMenuItem
+          key={innerKey}
+          className={className}
+          onClick={(e: any) => {
+            e.preventDefault()
+            handleClickOpen()
+          }}
+        >
+          {icon}
+          {label}
+        </MuiMenuItem>
+      ) : (
+        <Button
+          variant={variant}
+          startIcon={startIcon}
+          color={color}
+          onClick={handleClickOpen}
+          size={size}
+          disabled={disabled}
+          className={className}
+        >
+          {label}
+          {!startIcon && icon}
+        </Button>
+      )}
+      <Dialog
+        fullScreen
+        open={open}
+        onClose={handleClose}
+        TransitionComponent={Transition}
+        PaperProps={{
+          sx: {
+            paddingTop: isElectron() && platform !== 'darwin' ? '32px' : 0
+          }
+        }}
+      >
+        <AppBar enableColorOnDark className={classes.appBar}>
+          <Toolbar>
+            <Button
+              autoFocus
+              color="primary"
+              variant="contained"
+              startIcon={<NavigateBefore />}
+              onClick={handleClose}
+              style={{ marginRight: '1rem' }}
+            >
+              back
+            </Button>
+            <Typography variant="h6" className={classes.title}>
+              DMX Input Mappings
+            </Typography>
+          </Toolbar>
+        </AppBar>
+        <Box sx={{ margin: '1rem' }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+            <DialogAddDmxMapping integrationId={integrationId} />
+          </Box>
+          <DmxMappingTable integrationId={integrationId} />
+          <Box sx={{ mt: 3 }}>
+            <DmxLiveMonitor integrationId={integrationId} open={open} />
+          </Box>
+          <Typography variant="body2" sx={{ mt: 2, opacity: 0.7 }}>
+            Map DMX channels (e.g. from SoundSwitch via Art-Net) to venue color overrides, live
+            colour passthrough, or DMX wash fixtures. Use the live monitor below to learn which
+            channel a button or fader uses.
+          </Typography>
+        </Box>
+      </Dialog>
+    </>
+  )
+}

--- a/src/pages/Integrations/DmxInput/DmxInputScreen/DmxInputScreen.tsx
+++ b/src/pages/Integrations/DmxInput/DmxInputScreen/DmxInputScreen.tsx
@@ -59,6 +59,7 @@ export default function DmxInputScreen({
           size={size}
           disabled={disabled}
           className={className}
+          aria-label={label || 'DMX Input settings'}
         >
           {label}
           {!startIcon && icon}

--- a/src/pages/Integrations/IntegrationCard/IntegrationCardDmxInput.tsx
+++ b/src/pages/Integrations/IntegrationCard/IntegrationCardDmxInput.tsx
@@ -1,0 +1,156 @@
+import { useState } from 'react'
+import Card from '@mui/material/Card'
+import Button from '@mui/material/Button'
+import EditIcon from '@mui/icons-material/Edit'
+import SettingsIcon from '@mui/icons-material/Settings'
+import Collapse from '@mui/material/Collapse'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
+import IconButton from '@mui/material/IconButton'
+import { CardActions, CardHeader, Switch, Link, useTheme, Avatar } from '@mui/material'
+import { QuestionMark } from '@mui/icons-material'
+import Popover from '../../../components/Popover/Popover'
+import useStore from '../../../store/useStore'
+import useIntegrationCardStyles from './IntegrationCard.styles'
+import DmxInputScreen from '../DmxInput/DmxInputScreen/DmxInputScreen'
+
+const IntegrationCardDmxInput = ({ integration }: any) => {
+  const classes = useIntegrationCardStyles()
+  const theme = useTheme()
+  const getIntegrations = useStore((state) => state.getIntegrations)
+  const integrations = useStore((state) => state.integrations)
+  const deleteIntegration = useStore((state) => state.deleteIntegration)
+  const toggleIntegration = useStore((state) => state.toggleIntegration)
+  const setDialogOpenAddIntegration = useStore((state) => state.setDialogOpenAddIntegration)
+
+  const [expanded, setExpanded] = useState(false)
+  const variant = 'outlined'
+  const color = 'inherit'
+
+  const handleExpandClick = () => setExpanded(!expanded)
+
+  const handleDeleteDevice = (integ: string) => {
+    deleteIntegration(integrations[integ].id).then(() => getIntegrations())
+  }
+
+  const handleEditIntegration = (integ: any) => {
+    setDialogOpenAddIntegration(true, integ)
+  }
+
+  const handleActivateIntegration = (integ: any) => {
+    toggleIntegration({ id: integ.id }).then(() => getIntegrations())
+  }
+
+  return integrations[integration]?.config ? (
+    <Card className={classes.integrationCardPortrait}>
+      <CardHeader
+        title={integrations[integration].config.name}
+        subheader={`Current Status: ${
+          integrations[integration].status === 3
+            ? 'Connecting...'
+            : integrations[integration].status === 2
+              ? 'Disconnecting'
+              : integrations[integration].status === 1
+                ? 'Listening'
+                : integrations[integration].status === 0
+                  ? 'Disconnected'
+                  : 'Unknown'
+        }`}
+        action={
+          <Switch
+            aria-label="status"
+            checked={integrations[integration].active}
+            onClick={() => handleActivateIntegration(integrations[integration])}
+          />
+        }
+        avatar={
+          <Avatar aria-label="dmx" sx={{ width: 56, height: 56, color: '#fff' }}>
+            DMX
+          </Avatar>
+        }
+      />
+
+      <CardActions style={{ alignSelf: 'flex-end' }}>
+        <div className={classes.integrationCardContainer}>
+          <IconButton
+            sx={[
+              {
+                display: 'none',
+                marginLeft: 'auto',
+                transition: theme.transitions.create('transform', {
+                  duration: theme.transitions.duration.shortest
+                }),
+                '@media (max-width: 580px)': {
+                  display: 'block'
+                }
+              },
+              expanded ? { transform: 'rotate(180deg)' } : { transform: 'rotate(0deg)' }
+            ]}
+            onClick={handleExpandClick}
+            aria-expanded={expanded}
+            aria-label="show more"
+          >
+            <ExpandMoreIcon />
+          </IconButton>
+          <div className={classes.buttonBar}>
+            <Popover
+              variant={variant}
+              color={color}
+              onConfirm={() => handleDeleteDevice(integration)}
+              className={classes.editButton}
+            />
+            <Button
+              variant={variant}
+              size="small"
+              color={color}
+              className={classes.editButton}
+              onClick={() => handleEditIntegration(integration)}
+            >
+              <EditIcon />
+            </Button>
+            {integrations[integration].status !== 1 && (
+              <Link
+                target="_blank"
+                href="https://ledfx.readthedocs.io/en/latest/howto/soundswitch_dmx.html"
+                color={color}
+              >
+                <Button variant={variant} size="small" color={color} className={classes.editButton}>
+                  <QuestionMark />
+                </Button>
+              </Link>
+            )}
+            <DmxInputScreen
+              integrationId={integrations[integration].id}
+              icon={<SettingsIcon />}
+              variant={variant}
+              color={color}
+              className={classes.editButton}
+              disabled={integrations[integration].status !== 1}
+            />
+          </div>
+        </div>
+
+        <Collapse in={expanded} timeout="auto" unmountOnExit className={classes.buttonBarMobile}>
+          <div className={classes.buttonBarMobileWrapper}>
+            <Popover
+              variant={variant}
+              color={color}
+              onConfirm={() => handleDeleteDevice(integration)}
+              className={classes.editButton}
+            />
+            <Button
+              variant={variant}
+              size="small"
+              color={color}
+              className={classes.editButtonMobile}
+              onClick={() => handleEditIntegration(integration)}
+            >
+              <EditIcon />
+            </Button>
+          </div>
+        </Collapse>
+      </CardActions>
+    </Card>
+  ) : null
+}
+
+export default IntegrationCardDmxInput

--- a/src/pages/Integrations/Integrations.tsx
+++ b/src/pages/Integrations/Integrations.tsx
@@ -5,6 +5,7 @@ import IntegrationCard from './IntegrationCard/IntegrationCard'
 import NoYet from '../../components/NoYet'
 import IntegrationCardSpotify from './IntegrationCard/IntegrationCardSpotify'
 import IntegrationCardQLC from './IntegrationCard/IntegrationCardQLC'
+import IntegrationCardDmxInput from './IntegrationCard/IntegrationCardDmxInput'
 
 const useStyles = makeStyles(() => ({
   cardWrapper: {
@@ -36,6 +37,8 @@ const Integrations = () => {
             <IntegrationCardSpotify integration={integration} key={i} />
           ) : integrations[integration].type === 'qlc' ? (
             <IntegrationCardQLC integration={integration} key={i} />
+          ) : integrations[integration].type === 'dmx_input' ? (
+            <IntegrationCardDmxInput integration={integration} key={i} />
           ) : (
             <IntegrationCard integration={integration} key={i} />
           )

--- a/src/pages/Pages.tsx
+++ b/src/pages/Pages.tsx
@@ -33,6 +33,7 @@ import Home from './Home/Home'
 import User from './User/User'
 import Lock from './Lock'
 import '../App.css'
+import VenuesPage from './Venues/VenuesPage'
 
 const Routings = () => {
   const isElect = isElectron()
@@ -71,6 +72,7 @@ const Routings = () => {
               <Route path="/playlists" element={<BackendPlaylistPage />} />
               {!guest && <Route path="/integrations" element={<Integrations />} />}
               {!guest && <Route path="/settings" element={<SettingsNew />} />}
+              <Route path="/venues" element={<VenuesPage />} />
 
               <Route path="*" element={!guest ? <Home /> : <Scenes />} />
             </>

--- a/src/pages/Pages.tsx
+++ b/src/pages/Pages.tsx
@@ -34,6 +34,7 @@ import User from './User/User'
 import Lock from './Lock'
 import '../App.css'
 import VenuesPage from './Venues/VenuesPage'
+import VenueViewPage from './Venues/VenueViewPage'
 
 const Routings = () => {
   const isElect = isElectron()
@@ -73,6 +74,7 @@ const Routings = () => {
               {!guest && <Route path="/integrations" element={<Integrations />} />}
               {!guest && <Route path="/settings" element={<SettingsNew />} />}
               <Route path="/venues" element={<VenuesPage />} />
+              <Route path="/venues/:venueId" element={<VenueViewPage />} />
 
               <Route path="*" element={!guest ? <Home /> : <Scenes />} />
             </>

--- a/src/pages/Venues/ColorPadGrid.tsx
+++ b/src/pages/Venues/ColorPadGrid.tsx
@@ -1,0 +1,220 @@
+import { useCallback, useState, useRef } from 'react'
+import { Box, Tooltip, Paper, Dialog, DialogTitle, DialogContent, DialogActions, Button, Typography } from '@mui/material'
+import useStore from '../../store/useStore'
+import type { Venue, ColorPad } from '../../store/api/storeVenues'
+import GradientPicker from '../../components/SchemaForm/components/GradientPicker/GradientPicker'
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/** Return a CSS background string for a pad (solid color or gradient). */
+function padBackground(pad: ColorPad): string {
+  if (pad.gradient) return pad.gradient
+  if (pad.color) return pad.color
+  return '#444'
+}
+
+/** Return true if the color is visually dark (for text contrast). */
+function isDark(cssColor: string): boolean {
+  if (cssColor.startsWith('linear-gradient')) return true
+  try {
+    const c = cssColor.replace('#', '')
+    if (c.length !== 6) return true
+    const r = parseInt(c.slice(0, 2), 16)
+    const g = parseInt(c.slice(2, 4), 16)
+    const b = parseInt(c.slice(4, 6), 16)
+    return (r * 299 + g * 587 + b * 114) / 1000 < 128
+  } catch {
+    return true
+  }
+}
+
+// ─── Pad editor dialog ───────────────────────────────────────────────────────
+
+interface PadEditorProps {
+  open: boolean
+  pad: ColorPad
+  onClose: () => void
+  onSave: (pad: ColorPad) => void
+}
+
+function PadEditorDialog({ open, pad, onClose, onSave }: PadEditorProps) {
+  const [currentColor, setCurrentColor] = useState<string>(pad.gradient ?? pad.color ?? '#ff0000')
+  const colors = useStore((state) => state.colors)
+  const getColors = useStore((state) => state.getColors)
+  const addColor = useStore((state) => state.addColor)
+  const showHex = useStore((state) => state.uiPersist.showHex)
+
+  // Fetch colors on first open
+  const fetchedRef = useRef(false)
+  if (open && !fetchedRef.current) {
+    fetchedRef.current = true
+    if (!colors || Object.keys(colors).length === 0) getColors()
+  }
+
+  const handleColorChange = useCallback((value: string) => {
+    setCurrentColor(value)
+  }, [])
+
+  const handleSave = () => {
+    const isGradient = currentColor.includes('gradient')
+    onSave(isGradient ? { gradient: currentColor } : { color: currentColor })
+    onClose()
+  }
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm">
+      <DialogTitle>Edit Pad Color</DialogTitle>
+      <DialogContent>
+        <GradientPicker
+          pickerBgColor={currentColor}
+          isGradient={currentColor.includes('gradient')}
+          colors={colors}
+          sendColorToVirtuals={handleColorChange}
+          handleAddGradient={(name: string, color: string) => addColor({ [name]: color })}
+          showHex={showHex}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button onClick={handleSave} variant="contained">
+          Apply
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}
+
+// ─── Color Pad Grid ──────────────────────────────────────────────────────────
+
+interface Props {
+  venue: Venue
+}
+
+export default function ColorPadGrid({ venue }: Props) {
+  const activeVenueId = useStore((state) => state.activeVenueId)
+  const activeOverridePadIndex = useStore((state) => state.activeOverridePadIndex)
+  const activateVenueOverride = useStore((state) => state.activateVenueOverride)
+  const clearVenueOverride = useStore((state) => state.clearVenueOverride)
+  const updateVenuePad = useStore((state) => state.updateVenuePad)
+
+  const [editingPadIndex, setEditingPadIndex] = useState<number | null>(null)
+  const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const { rows, cols, pads } = venue.color_pads
+
+  const handlePointerDown = useCallback(
+    (index: number) => {
+      longPressTimer.current = setTimeout(() => {
+        longPressTimer.current = null
+        setEditingPadIndex(index)
+      }, 600)
+    },
+    []
+  )
+
+  const handlePointerUp = useCallback(
+    (index: number) => {
+      if (longPressTimer.current !== null) {
+        clearTimeout(longPressTimer.current)
+        longPressTimer.current = null
+        // Short tap → toggle override
+        if (activeOverridePadIndex === index) {
+          clearVenueOverride(venue.id)
+        } else {
+          activateVenueOverride(venue.id, index)
+        }
+      }
+    },
+    [activeOverridePadIndex, venue.id, activateVenueOverride, clearVenueOverride]
+  )
+
+  const handleContextMenu = useCallback(
+    (e: React.MouseEvent, index: number) => {
+      e.preventDefault()
+      setEditingPadIndex(index)
+    },
+    []
+  )
+
+  const handlePadSave = useCallback(
+    async (pad: ColorPad) => {
+      if (editingPadIndex === null) return
+      await updateVenuePad(venue.id, editingPadIndex, pad)
+    },
+    [editingPadIndex, venue.id, updateVenuePad]
+  )
+
+  return (
+    <>
+      <Box
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: `repeat(${cols}, 1fr)`,
+          gap: 1,
+          maxWidth: cols * 72,
+          mb: 1
+        }}
+      >
+        {pads.map((pad, i) => {
+          const isActive = activeVenueId === venue.id && activeOverridePadIndex === i
+          const bg = padBackground(pad)
+          const textColor = isDark(bg) ? '#fff' : '#000'
+          const row = Math.floor(i / cols) + 1
+          const col = (i % cols) + 1
+          return (
+            <Tooltip
+              key={i}
+              title={`Pad ${row}×${col} — long-press or right-click to edit`}
+              placement="top"
+            >
+              <Paper
+                elevation={isActive ? 8 : 2}
+                onPointerDown={() => handlePointerDown(i)}
+                onPointerUp={() => handlePointerUp(i)}
+                onPointerLeave={() => {
+                  if (longPressTimer.current) {
+                    clearTimeout(longPressTimer.current)
+                    longPressTimer.current = null
+                  }
+                }}
+                onContextMenu={(e) => handleContextMenu(e, i)}
+                sx={{
+                  width: 64,
+                  height: 64,
+                  background: bg,
+                  cursor: 'pointer',
+                  border: isActive ? `3px solid white` : '3px solid transparent',
+                  outline: isActive ? '2px solid rgba(255,255,255,0.5)' : 'none',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  userSelect: 'none',
+                  transition: 'all 0.15s',
+                  '&:hover': { opacity: 0.85 }
+                }}
+              >
+                {isActive && (
+                  <Typography variant="caption" sx={{ color: textColor, fontWeight: 'bold' }}>
+                    ON
+                  </Typography>
+                )}
+              </Paper>
+            </Tooltip>
+          )
+        })}
+      </Box>
+      <Typography variant="caption" color="text.secondary">
+        Tap a pad to activate color override · Tap again to clear · Long-press or right-click to
+        edit color
+      </Typography>
+      {editingPadIndex !== null && (
+        <PadEditorDialog
+          open
+          pad={pads[editingPadIndex]}
+          onClose={() => setEditingPadIndex(null)}
+          onSave={handlePadSave}
+        />
+      )}
+    </>
+  )
+}

--- a/src/pages/Venues/ColorPadGrid.tsx
+++ b/src/pages/Venues/ColorPadGrid.tsx
@@ -44,14 +44,44 @@ function defaultPadColor(padIndex: number, totalPads: number): string {
   const c = (1 - Math.abs(2 * l - 1)) * s
   const x = c * (1 - Math.abs(((h / 60) % 2) - 1))
   const m = l - c / 2
-  let r = 0, g = 0, b = 0
-  if (h < 60) { r = c; g = x; b = 0 }
-  else if (h < 120) { r = x; g = c; b = 0 }
-  else if (h < 180) { r = 0; g = c; b = x }
-  else if (h < 240) { r = 0; g = x; b = c }
-  else if (h < 300) { r = x; g = 0; b = c }
-  else { r = c; g = 0; b = x }
-  return '#' + [r + m, g + m, b + m].map((v) => Math.round(v * 255).toString(16).padStart(2, '0')).join('')
+  let r = 0
+  let g = 0
+  let b = 0
+  if (h < 60) {
+    r = c
+    g = x
+    b = 0
+  } else if (h < 120) {
+    r = x
+    g = c
+    b = 0
+  } else if (h < 180) {
+    r = 0
+    g = c
+    b = x
+  } else if (h < 240) {
+    r = 0
+    g = x
+    b = c
+  } else if (h < 300) {
+    r = x
+    g = 0
+    b = c
+  } else {
+    r = c
+    g = 0
+    b = x
+  }
+  return (
+    '#' +
+    [r + m, g + m, b + m]
+      .map((v) =>
+        Math.round(v * 255)
+          .toString(16)
+          .padStart(2, '0')
+      )
+      .join('')
+  )
 }
 
 /** Build the background sx props for a pad. Gradients require backgroundImage. */
@@ -67,8 +97,8 @@ function padSx(pad: ColorPad, padSize: number, isActive: boolean, isEditMode: bo
     border: isActive
       ? '3px solid white'
       : isEditMode
-      ? '3px dashed rgba(255,255,255,0.4)'
-      : '3px solid transparent',
+        ? '3px dashed rgba(255,255,255,0.4)'
+        : '3px solid transparent',
     outline: isActive ? '2px solid rgba(255,255,255,0.5)' : 'none',
     display: 'flex',
     alignItems: 'center',
@@ -122,10 +152,13 @@ function PadEditorDialog({ open, pad, padIndex, totalPads, onClose, onSave }: Pa
   }, [open, pad, colors, getColors])
 
   const defaultColors: string[] = []
-  if (colors?.gradients?.builtin) defaultColors.push(...Object.values(colors.gradients.builtin) as string[])
-  if (colors?.gradients?.user) defaultColors.push(...Object.values(colors.gradients.user) as string[])
-  if (colors?.colors?.builtin) defaultColors.push(...Object.values(colors.colors.builtin) as string[])
-  if (colors?.colors?.user) defaultColors.push(...Object.values(colors.colors.user) as string[])
+  if (colors?.gradients?.builtin)
+    defaultColors.push(...(Object.values(colors.gradients.builtin) as string[]))
+  if (colors?.gradients?.user)
+    defaultColors.push(...(Object.values(colors.gradients.user) as string[]))
+  if (colors?.colors?.builtin)
+    defaultColors.push(...(Object.values(colors.colors.builtin) as string[]))
+  if (colors?.colors?.user) defaultColors.push(...(Object.values(colors.colors.user) as string[]))
 
   const handleSave = () => {
     const isGradient = currentColor.includes('gradient')
@@ -194,9 +227,15 @@ function PadEditorDialog({ open, pad, padIndex, totalPads, onClose, onSave }: Pa
       <DialogActions sx={{ justifyContent: 'space-between', px: 2 }}>
         {confirmReset ? (
           <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
-            <Typography variant="caption" color="warning.main">Reset to default?</Typography>
-            <Button size="small" color="warning" onClick={handleResetClick}>Confirm</Button>
-            <Button size="small" onClick={() => setConfirmReset(false)}>Cancel</Button>
+            <Typography variant="caption" color="warning.main">
+              Reset to default?
+            </Typography>
+            <Button size="small" color="warning" onClick={handleResetClick}>
+              Confirm
+            </Button>
+            <Button size="small" onClick={() => setConfirmReset(false)}>
+              Cancel
+            </Button>
           </Box>
         ) : (
           <Button size="small" color="inherit" onClick={handleResetClick}>
@@ -247,7 +286,14 @@ export default function ColorPadGrid({ venue, isEditMode }: Props) {
         }
       }
     },
-    [isEditMode, activeOverridePadIndex, activeVenueId, venue.id, activateVenueOverride, clearVenueOverride]
+    [
+      isEditMode,
+      activeOverridePadIndex,
+      activeVenueId,
+      venue.id,
+      activateVenueOverride,
+      clearVenueOverride
+    ]
   )
 
   const handlePadSave = useCallback(
@@ -262,7 +308,9 @@ export default function ColorPadGrid({ venue, isEditMode }: Props) {
     <>
       {/* Size selector */}
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
-        <Typography variant="caption" color="text.secondary">Size:</Typography>
+        <Typography variant="caption" color="text.secondary">
+          Size:
+        </Typography>
         <ToggleButtonGroup
           size="small"
           value={padSizeKey}
@@ -291,18 +339,18 @@ export default function ColorPadGrid({ venue, isEditMode }: Props) {
           const isActive = activeVenueId === venue.id && activeOverridePadIndex === i
           const textColor = isDark(pad) ? '#fff' : '#000'
           return (
-              <Paper
-                key={i}
-                elevation={isActive ? 8 : 2}
-                onClick={() => handleClick(i)}
-                sx={padSx(pad, padSize, isActive, isEditMode)}
-              >
-                {isActive && !isEditMode && (
-                  <Typography variant="caption" sx={{ color: textColor, fontWeight: 'bold' }}>
-                    ON
-                  </Typography>
-                )}
-              </Paper>
+            <Paper
+              key={i}
+              elevation={isActive ? 8 : 2}
+              onClick={() => handleClick(i)}
+              sx={padSx(pad, padSize, isActive, isEditMode)}
+            >
+              {isActive && !isEditMode && (
+                <Typography variant="caption" sx={{ color: textColor, fontWeight: 'bold' }}>
+                  ON
+                </Typography>
+              )}
+            </Paper>
           )
         })}
       </Box>

--- a/src/pages/Venues/ColorPadGrid.tsx
+++ b/src/pages/Venues/ColorPadGrid.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import ReactGPicker from 'react-gcolor-picker'
 import {
   Box,
@@ -24,8 +24,16 @@ type PadSizeKey = keyof typeof PAD_SIZES
 /** Normalize a gradient string to always include an explicit angle. */
 function normalizeGradient(colorStr: string): string {
   if (!colorStr || !colorStr.includes('linear-gradient')) return colorStr
-  if (colorStr.match(/linear-gradient\s*\(\s*\d+deg/)) return colorStr
-  return colorStr.replace(/linear-gradient\s*\(/, 'linear-gradient(90deg, ')
+  // No angle specified — add 90deg (left-to-right)
+  if (!colorStr.match(/linear-gradient\s*\(\s*\d+deg/)) {
+    return colorStr.replace(/linear-gradient\s*\(/, 'linear-gradient(90deg, ')
+  }
+  return colorStr
+}
+
+/** Replace 180deg (ReactGPicker's first-time default) with 90deg. */
+function fixDefaultAngle(colorStr: string): string {
+  return colorStr.replace(/linear-gradient\s*\(\s*180deg/, 'linear-gradient(90deg')
 }
 
 /** Return the auto-palette default hex color for pad i of n (mirrors backend). */
@@ -55,6 +63,7 @@ function padSx(pad: ColorPad, padSize: number, isActive: boolean, isEditMode: bo
     width: padSize,
     height: padSize,
     ...(isGrad ? { backgroundImage: bg, backgroundColor: 'transparent' } : { backgroundColor: bg }),
+    backgroundClip: 'padding-box',
     cursor: 'pointer',
     border: isActive
       ? '3px solid white'
@@ -97,14 +106,18 @@ function PadEditorDialog({ open, pad, padIndex, totalPads, onClose, onSave }: Pa
   const initialColor = normalizeGradient(pad.gradient ?? pad.color ?? '#ff0000')
   const [currentColor, setCurrentColor] = useState<string>(initialColor)
   const [confirmReset, setConfirmReset] = useState(false)
+  // Tracks whether the picker had a gradient value before the most recent onChange
+  const wasGradientRef = useRef(Boolean(pad.gradient))
 
   const colors = useStore((state) => state.colors)
   const getColors = useStore((state) => state.getColors)
 
   useEffect(() => {
     if (open) {
-      setCurrentColor(normalizeGradient(pad.gradient ?? pad.color ?? '#ff0000'))
+      const c = normalizeGradient(pad.gradient ?? pad.color ?? '#ff0000')
+      setCurrentColor(c)
       setConfirmReset(false)
+      wasGradientRef.current = c.includes('gradient')
       if (!colors || Object.keys(colors).length === 0) getColors()
     }
   }, [open, pad, colors, getColors])
@@ -121,9 +134,22 @@ function PadEditorDialog({ open, pad, padIndex, totalPads, onClose, onSave }: Pa
     onClose()
   }
 
+  const handleChange = (c: string) => {
+    let normalized = normalizeGradient(c)
+    const isNowGradient = normalized.includes('gradient')
+    // Fix ReactGPicker's 180deg default only on the first solid→gradient switch
+    if (isNowGradient && !wasGradientRef.current) {
+      normalized = fixDefaultAngle(normalized)
+    }
+    wasGradientRef.current = isNowGradient
+    setCurrentColor(normalized)
+  }
+
   const handleResetClick = () => {
     if (confirmReset) {
-      setCurrentColor(defaultPadColor(padIndex, totalPads))
+      const def = defaultPadColor(padIndex, totalPads)
+      setCurrentColor(def)
+      wasGradientRef.current = false
       setConfirmReset(false)
     } else {
       setConfirmReset(true)
@@ -134,19 +160,37 @@ function PadEditorDialog({ open, pad, padIndex, totalPads, onClose, onSave }: Pa
     <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
       <DialogTitle>Edit Pad Color</DialogTitle>
       <DialogContent sx={{ pt: 1, pb: 0 }}>
-        <ReactGPicker
-          colorBoardHeight={150}
-          debounce
-          debounceMS={200}
-          format="hex"
-          gradient
-          solid
-          showAlpha={false}
-          popupWidth={288}
-          value={currentColor}
-          defaultColors={defaultColors}
-          onChange={(c: string) => setCurrentColor(normalizeGradient(c))}
-        />
+        {/* Override ReactGPicker's hardcoded white backgrounds to match app theme */}
+        <Box
+          sx={(theme) => ({
+            '& .colorpicker, & .popup_tabs, & .popup_tabs-header, & .color-picker-panel': {
+              backgroundColor: `${theme.palette.background.paper} !important`
+            },
+            '& .popup_tabs-header-label': {
+              color: `${theme.palette.text.secondary} !important`
+            },
+            '& .popup_tabs-header-label-active': {
+              color: `${theme.palette.text.primary} !important`,
+              backgroundColor: `${theme.palette.background.paper} !important`
+            },
+            '& .gradient-result': { display: 'none' },
+            '& .input_rgba': { display: 'none' }
+          })}
+        >
+          <ReactGPicker
+            colorBoardHeight={150}
+            debounce
+            debounceMS={200}
+            format="hex"
+            gradient
+            solid
+            showAlpha={false}
+            popupWidth={288}
+            value={currentColor}
+            defaultColors={defaultColors}
+            onChange={handleChange}
+          />
+        </Box>
       </DialogContent>
       <DialogActions sx={{ justifyContent: 'space-between', px: 2 }}>
         {confirmReset ? (

--- a/src/pages/Venues/ColorPadGrid.tsx
+++ b/src/pages/Venues/ColorPadGrid.tsx
@@ -100,7 +100,7 @@ export default function ColorPadGrid({ venue }: Props) {
   const [editingPadIndex, setEditingPadIndex] = useState<number | null>(null)
   const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-  const { rows, cols, pads } = venue.color_pads
+  const { cols, pads } = venue.color_pads
 
   const handlePointerDown = useCallback(
     (index: number) => {

--- a/src/pages/Venues/ColorPadGrid.tsx
+++ b/src/pages/Venues/ColorPadGrid.tsx
@@ -341,6 +341,7 @@ export default function ColorPadGrid({ venue, isEditMode }: Props) {
           return (
             <Paper
               key={i}
+              data-testid={`color-pad-${i}`}
               elevation={isActive ? 8 : 2}
               onClick={() => handleClick(i)}
               sx={padSx(pad, padSize, isActive, isEditMode)}

--- a/src/pages/Venues/ColorPadGrid.tsx
+++ b/src/pages/Venues/ColorPadGrid.tsx
@@ -67,7 +67,7 @@ function PadEditorDialog({ open, pad, onClose, onSave }: PadEditorProps) {
       <DialogContent>
         <GradientPicker
           pickerBgColor={currentColor}
-          isGradient={currentColor.includes('gradient')}
+          isGradient={true}
           colors={colors}
           sendColorToVirtuals={handleColorChange}
           handleAddGradient={(name: string, color: string) => addColor({ [name]: color })}
@@ -88,9 +88,10 @@ function PadEditorDialog({ open, pad, onClose, onSave }: PadEditorProps) {
 
 interface Props {
   venue: Venue
+  isEditMode: boolean
 }
 
-export default function ColorPadGrid({ venue }: Props) {
+export default function ColorPadGrid({ venue, isEditMode }: Props) {
   const activeVenueId = useStore((state) => state.activeVenueId)
   const activeOverridePadIndex = useStore((state) => state.activeOverridePadIndex)
   const activateVenueOverride = useStore((state) => state.activateVenueOverride)
@@ -98,42 +99,22 @@ export default function ColorPadGrid({ venue }: Props) {
   const updateVenuePad = useStore((state) => state.updateVenuePad)
 
   const [editingPadIndex, setEditingPadIndex] = useState<number | null>(null)
-  const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const { cols, pads } = venue.color_pads
 
-  const handlePointerDown = useCallback(
+  const handleClick = useCallback(
     (index: number) => {
-      longPressTimer.current = setTimeout(() => {
-        longPressTimer.current = null
+      if (isEditMode) {
         setEditingPadIndex(index)
-      }, 600)
-    },
-    []
-  )
-
-  const handlePointerUp = useCallback(
-    (index: number) => {
-      if (longPressTimer.current !== null) {
-        clearTimeout(longPressTimer.current)
-        longPressTimer.current = null
-        // Short tap → toggle override
-        if (activeOverridePadIndex === index) {
+      } else {
+        if (activeOverridePadIndex === index && activeVenueId === venue.id) {
           clearVenueOverride(venue.id)
         } else {
           activateVenueOverride(venue.id, index)
         }
       }
     },
-    [activeOverridePadIndex, venue.id, activateVenueOverride, clearVenueOverride]
-  )
-
-  const handleContextMenu = useCallback(
-    (e: React.MouseEvent, index: number) => {
-      e.preventDefault()
-      setEditingPadIndex(index)
-    },
-    []
+    [isEditMode, activeOverridePadIndex, activeVenueId, venue.id, activateVenueOverride, clearVenueOverride]
   )
 
   const handlePadSave = useCallback(
@@ -164,26 +145,22 @@ export default function ColorPadGrid({ venue }: Props) {
           return (
             <Tooltip
               key={i}
-              title={`Pad ${row}×${col} — long-press or right-click to edit`}
+              title={isEditMode ? `Edit pad ${row}×${col}` : `Pad ${row}×${col}`}
               placement="top"
             >
               <Paper
                 elevation={isActive ? 8 : 2}
-                onPointerDown={() => handlePointerDown(i)}
-                onPointerUp={() => handlePointerUp(i)}
-                onPointerLeave={() => {
-                  if (longPressTimer.current) {
-                    clearTimeout(longPressTimer.current)
-                    longPressTimer.current = null
-                  }
-                }}
-                onContextMenu={(e) => handleContextMenu(e, i)}
+                onClick={() => handleClick(i)}
                 sx={{
                   width: 64,
                   height: 64,
                   background: bg,
                   cursor: 'pointer',
-                  border: isActive ? `3px solid white` : '3px solid transparent',
+                  border: isActive
+                    ? '3px solid white'
+                    : isEditMode
+                    ? '3px dashed rgba(255,255,255,0.4)'
+                    : '3px solid transparent',
                   outline: isActive ? '2px solid rgba(255,255,255,0.5)' : 'none',
                   display: 'flex',
                   alignItems: 'center',
@@ -193,7 +170,7 @@ export default function ColorPadGrid({ venue }: Props) {
                   '&:hover': { opacity: 0.85 }
                 }}
               >
-                {isActive && (
+                {isActive && !isEditMode && (
                   <Typography variant="caption" sx={{ color: textColor, fontWeight: 'bold' }}>
                     ON
                   </Typography>
@@ -204,8 +181,9 @@ export default function ColorPadGrid({ venue }: Props) {
         })}
       </Box>
       <Typography variant="caption" color="text.secondary">
-        Tap a pad to activate color override · Tap again to clear · Long-press or right-click to
-        edit color
+        {isEditMode
+          ? 'Click a pad to change its color or gradient'
+          : 'Tap a pad to activate color override · Tap again to clear'}
       </Typography>
       {editingPadIndex !== null && (
         <PadEditorDialog

--- a/src/pages/Venues/ColorPadGrid.tsx
+++ b/src/pages/Venues/ColorPadGrid.tsx
@@ -1,31 +1,85 @@
-import { useCallback, useState, useRef } from 'react'
-import { Box, Tooltip, Paper, Dialog, DialogTitle, DialogContent, DialogActions, Button, Typography } from '@mui/material'
+import { useCallback, useEffect, useState } from 'react'
+import ReactGPicker from 'react-gcolor-picker'
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Paper,
+  ToggleButton,
+  ToggleButtonGroup,
+  Tooltip,
+  Typography
+} from '@mui/material'
 import useStore from '../../store/useStore'
-import type { Venue, ColorPad } from '../../store/api/storeVenues'
-import GradientPicker from '../../components/SchemaForm/components/GradientPicker/GradientPicker'
+import type { ColorPad, Venue } from '../../store/api/storeVenues'
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
-/** Return a CSS background string for a pad (solid color or gradient). */
-function padBackground(pad: ColorPad): string {
-  if (pad.gradient) return pad.gradient
-  if (pad.color) return pad.color
-  return '#444'
+const PAD_SIZES = { S: 40, M: 56, L: 72, XL: 96 } as const
+type PadSizeKey = keyof typeof PAD_SIZES
+
+/** Normalize a gradient string to always include an explicit angle. */
+function normalizeGradient(colorStr: string): string {
+  if (!colorStr || !colorStr.includes('linear-gradient')) return colorStr
+  if (colorStr.match(/linear-gradient\s*\(\s*\d+deg/)) return colorStr
+  return colorStr.replace(/linear-gradient\s*\(/, 'linear-gradient(90deg, ')
 }
 
-/** Return true if the color is visually dark (for text contrast). */
-function isDark(cssColor: string): boolean {
-  if (cssColor.startsWith('linear-gradient')) return true
-  try {
-    const c = cssColor.replace('#', '')
-    if (c.length !== 6) return true
-    const r = parseInt(c.slice(0, 2), 16)
-    const g = parseInt(c.slice(2, 4), 16)
-    const b = parseInt(c.slice(4, 6), 16)
-    return (r * 299 + g * 587 + b * 114) / 1000 < 128
-  } catch {
-    return true
+/** Return the auto-palette default hex color for pad i of n (mirrors backend). */
+function defaultPadColor(padIndex: number, totalPads: number): string {
+  if (totalPads === 0) return '#ff0000'
+  const h = (padIndex / totalPads) * 360
+  const s = 1
+  const l = 0.5
+  const c = (1 - Math.abs(2 * l - 1)) * s
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1))
+  const m = l - c / 2
+  let r = 0, g = 0, b = 0
+  if (h < 60) { r = c; g = x; b = 0 }
+  else if (h < 120) { r = x; g = c; b = 0 }
+  else if (h < 180) { r = 0; g = c; b = x }
+  else if (h < 240) { r = 0; g = x; b = c }
+  else if (h < 300) { r = x; g = 0; b = c }
+  else { r = c; g = 0; b = x }
+  return '#' + [r + m, g + m, b + m].map((v) => Math.round(v * 255).toString(16).padStart(2, '0')).join('')
+}
+
+/** Build the background sx props for a pad. Gradients require backgroundImage. */
+function padSx(pad: ColorPad, padSize: number, isActive: boolean, isEditMode: boolean) {
+  const isGrad = Boolean(pad.gradient)
+  const bg = pad.gradient ?? pad.color ?? '#444'
+  return {
+    width: padSize,
+    height: padSize,
+    ...(isGrad ? { backgroundImage: bg, backgroundColor: 'transparent' } : { backgroundColor: bg }),
+    cursor: 'pointer',
+    border: isActive
+      ? '3px solid white'
+      : isEditMode
+      ? '3px dashed rgba(255,255,255,0.4)'
+      : '3px solid transparent',
+    outline: isActive ? '2px solid rgba(255,255,255,0.5)' : 'none',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    userSelect: 'none',
+    transition: 'all 0.15s',
+    '&:hover': { opacity: 0.85 }
   }
+}
+
+/** Return true if a background color is visually dark (for text contrast). */
+function isDark(pad: ColorPad): boolean {
+  if (pad.gradient) return true
+  const c = (pad.color ?? '#000').replace('#', '')
+  if (c.length !== 6) return true
+  const r = parseInt(c.slice(0, 2), 16)
+  const g = parseInt(c.slice(2, 4), 16)
+  const b = parseInt(c.slice(4, 6), 16)
+  return (r * 299 + g * 587 + b * 114) / 1000 < 128
 }
 
 // ─── Pad editor dialog ───────────────────────────────────────────────────────
@@ -33,27 +87,33 @@ function isDark(cssColor: string): boolean {
 interface PadEditorProps {
   open: boolean
   pad: ColorPad
+  padIndex: number
+  totalPads: number
   onClose: () => void
   onSave: (pad: ColorPad) => void
 }
 
-function PadEditorDialog({ open, pad, onClose, onSave }: PadEditorProps) {
-  const [currentColor, setCurrentColor] = useState<string>(pad.gradient ?? pad.color ?? '#ff0000')
+function PadEditorDialog({ open, pad, padIndex, totalPads, onClose, onSave }: PadEditorProps) {
+  const initialColor = normalizeGradient(pad.gradient ?? pad.color ?? '#ff0000')
+  const [currentColor, setCurrentColor] = useState<string>(initialColor)
+  const [confirmReset, setConfirmReset] = useState(false)
+
   const colors = useStore((state) => state.colors)
   const getColors = useStore((state) => state.getColors)
-  const addColor = useStore((state) => state.addColor)
-  const showHex = useStore((state) => state.uiPersist.showHex)
 
-  // Fetch colors on first open
-  const fetchedRef = useRef(false)
-  if (open && !fetchedRef.current) {
-    fetchedRef.current = true
-    if (!colors || Object.keys(colors).length === 0) getColors()
-  }
+  useEffect(() => {
+    if (open) {
+      setCurrentColor(normalizeGradient(pad.gradient ?? pad.color ?? '#ff0000'))
+      setConfirmReset(false)
+      if (!colors || Object.keys(colors).length === 0) getColors()
+    }
+  }, [open, pad, colors, getColors])
 
-  const handleColorChange = useCallback((value: string) => {
-    setCurrentColor(value)
-  }, [])
+  const defaultColors: string[] = []
+  if (colors?.gradients?.builtin) defaultColors.push(...Object.values(colors.gradients.builtin) as string[])
+  if (colors?.gradients?.user) defaultColors.push(...Object.values(colors.gradients.user) as string[])
+  if (colors?.colors?.builtin) defaultColors.push(...Object.values(colors.colors.builtin) as string[])
+  if (colors?.colors?.user) defaultColors.push(...Object.values(colors.colors.user) as string[])
 
   const handleSave = () => {
     const isGradient = currentColor.includes('gradient')
@@ -61,24 +121,51 @@ function PadEditorDialog({ open, pad, onClose, onSave }: PadEditorProps) {
     onClose()
   }
 
+  const handleResetClick = () => {
+    if (confirmReset) {
+      setCurrentColor(defaultPadColor(padIndex, totalPads))
+      setConfirmReset(false)
+    } else {
+      setConfirmReset(true)
+    }
+  }
+
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="sm">
+    <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
       <DialogTitle>Edit Pad Color</DialogTitle>
-      <DialogContent>
-        <GradientPicker
-          pickerBgColor={currentColor}
-          isGradient={true}
-          colors={colors}
-          sendColorToVirtuals={handleColorChange}
-          handleAddGradient={(name: string, color: string) => addColor({ [name]: color })}
-          showHex={showHex}
+      <DialogContent sx={{ pt: 1, pb: 0 }}>
+        <ReactGPicker
+          colorBoardHeight={150}
+          debounce
+          debounceMS={200}
+          format="hex"
+          gradient
+          solid
+          showAlpha={false}
+          popupWidth={288}
+          value={currentColor}
+          defaultColors={defaultColors}
+          onChange={(c: string) => setCurrentColor(normalizeGradient(c))}
         />
       </DialogContent>
-      <DialogActions>
-        <Button onClick={onClose}>Cancel</Button>
-        <Button onClick={handleSave} variant="contained">
-          Apply
-        </Button>
+      <DialogActions sx={{ justifyContent: 'space-between', px: 2 }}>
+        {confirmReset ? (
+          <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+            <Typography variant="caption" color="warning.main">Reset to default?</Typography>
+            <Button size="small" color="warning" onClick={handleResetClick}>Confirm</Button>
+            <Button size="small" onClick={() => setConfirmReset(false)}>Cancel</Button>
+          </Box>
+        ) : (
+          <Button size="small" color="inherit" onClick={handleResetClick}>
+            Reset to Default
+          </Button>
+        )}
+        <Box sx={{ display: 'flex', gap: 1 }}>
+          <Button onClick={onClose}>Cancel</Button>
+          <Button onClick={handleSave} variant="contained">
+            Apply
+          </Button>
+        </Box>
       </DialogActions>
     </Dialog>
   )
@@ -99,8 +186,11 @@ export default function ColorPadGrid({ venue, isEditMode }: Props) {
   const updateVenuePad = useStore((state) => state.updateVenuePad)
 
   const [editingPadIndex, setEditingPadIndex] = useState<number | null>(null)
+  const [padSizeKey, setPadSizeKey] = useState<PadSizeKey>('M')
+  const padSize = PAD_SIZES[padSizeKey]
 
   const { cols, pads } = venue.color_pads
+  const gap = 8
 
   const handleClick = useCallback(
     (index: number) => {
@@ -127,19 +217,36 @@ export default function ColorPadGrid({ venue, isEditMode }: Props) {
 
   return (
     <>
+      {/* Size selector */}
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+        <Typography variant="caption" color="text.secondary">Size:</Typography>
+        <ToggleButtonGroup
+          size="small"
+          value={padSizeKey}
+          exclusive
+          onChange={(_, v) => v && setPadSizeKey(v as PadSizeKey)}
+        >
+          {(Object.keys(PAD_SIZES) as PadSizeKey[]).map((k) => (
+            <ToggleButton key={k} value={k} sx={{ px: 1, py: 0.25, fontSize: '0.7rem' }}>
+              {k}
+            </ToggleButton>
+          ))}
+        </ToggleButtonGroup>
+      </Box>
+
+      {/* Pad grid */}
       <Box
         sx={{
           display: 'grid',
-          gridTemplateColumns: `repeat(${cols}, 1fr)`,
-          gap: 1,
-          maxWidth: cols * 72,
-          mb: 1
+          gridTemplateColumns: `repeat(${cols}, ${padSize}px)`,
+          gap: `${gap}px`,
+          mb: 1,
+          width: 'fit-content'
         }}
       >
         {pads.map((pad, i) => {
           const isActive = activeVenueId === venue.id && activeOverridePadIndex === i
-          const bg = padBackground(pad)
-          const textColor = isDark(bg) ? '#fff' : '#000'
+          const textColor = isDark(pad) ? '#fff' : '#000'
           const row = Math.floor(i / cols) + 1
           const col = (i % cols) + 1
           return (
@@ -151,24 +258,7 @@ export default function ColorPadGrid({ venue, isEditMode }: Props) {
               <Paper
                 elevation={isActive ? 8 : 2}
                 onClick={() => handleClick(i)}
-                sx={{
-                  width: 64,
-                  height: 64,
-                  background: bg,
-                  cursor: 'pointer',
-                  border: isActive
-                    ? '3px solid white'
-                    : isEditMode
-                    ? '3px dashed rgba(255,255,255,0.4)'
-                    : '3px solid transparent',
-                  outline: isActive ? '2px solid rgba(255,255,255,0.5)' : 'none',
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  userSelect: 'none',
-                  transition: 'all 0.15s',
-                  '&:hover': { opacity: 0.85 }
-                }}
+                sx={padSx(pad, padSize, isActive, isEditMode)}
               >
                 {isActive && !isEditMode && (
                   <Typography variant="caption" sx={{ color: textColor, fontWeight: 'bold' }}>
@@ -180,15 +270,19 @@ export default function ColorPadGrid({ venue, isEditMode }: Props) {
           )
         })}
       </Box>
+
       <Typography variant="caption" color="text.secondary">
         {isEditMode
           ? 'Click a pad to change its color or gradient'
           : 'Tap a pad to activate color override · Tap again to clear'}
       </Typography>
+
       {editingPadIndex !== null && (
         <PadEditorDialog
           open
           pad={pads[editingPadIndex]}
+          padIndex={editingPadIndex}
+          totalPads={pads.length}
           onClose={() => setEditingPadIndex(null)}
           onSave={handlePadSave}
         />

--- a/src/pages/Venues/ColorPadGrid.tsx
+++ b/src/pages/Venues/ColorPadGrid.tsx
@@ -10,7 +10,6 @@ import {
   Paper,
   ToggleButton,
   ToggleButtonGroup,
-  Tooltip,
   Typography
 } from '@mui/material'
 import useStore from '../../store/useStore'
@@ -230,7 +229,7 @@ export default function ColorPadGrid({ venue, isEditMode }: Props) {
   const updateVenuePad = useStore((state) => state.updateVenuePad)
 
   const [editingPadIndex, setEditingPadIndex] = useState<number | null>(null)
-  const [padSizeKey, setPadSizeKey] = useState<PadSizeKey>('M')
+  const [padSizeKey, setPadSizeKey] = useState<PadSizeKey>('XL')
   const padSize = PAD_SIZES[padSizeKey]
 
   const { cols, pads } = venue.color_pads
@@ -291,15 +290,9 @@ export default function ColorPadGrid({ venue, isEditMode }: Props) {
         {pads.map((pad, i) => {
           const isActive = activeVenueId === venue.id && activeOverridePadIndex === i
           const textColor = isDark(pad) ? '#fff' : '#000'
-          const row = Math.floor(i / cols) + 1
-          const col = (i % cols) + 1
           return (
-            <Tooltip
-              key={i}
-              title={isEditMode ? `Edit pad ${row}×${col}` : `Pad ${row}×${col}`}
-              placement="top"
-            >
               <Paper
+                key={i}
                 elevation={isActive ? 8 : 2}
                 onClick={() => handleClick(i)}
                 sx={padSx(pad, padSize, isActive, isEditMode)}
@@ -310,7 +303,6 @@ export default function ColorPadGrid({ venue, isEditMode }: Props) {
                   </Typography>
                 )}
               </Paper>
-            </Tooltip>
           )
         })}
       </Box>

--- a/src/pages/Venues/VenueView.tsx
+++ b/src/pages/Venues/VenueView.tsx
@@ -1,13 +1,5 @@
 import { useCallback, useState } from 'react'
-import {
-  Box,
-  Button,
-  Chip,
-  Typography,
-  Divider,
-  Autocomplete,
-  TextField
-} from '@mui/material'
+import { Box, Button, Chip, Typography, Divider, Autocomplete, TextField } from '@mui/material'
 import { ArrowBack } from '@mui/icons-material'
 import useStore from '../../store/useStore'
 import type { Venue } from '../../store/api/storeVenues'
@@ -53,9 +45,7 @@ export default function VenueView({ venue, onLeave }: Props) {
     [venue.id, removeVirtualFromVenue]
   )
 
-  const memberVirtuals = venue.virtual_ids
-    .map((id) => virtuals[id])
-    .filter(Boolean)
+  const memberVirtuals = venue.virtual_ids.map((id) => virtuals[id]).filter(Boolean)
 
   const notYetAdded = availableVirtuals.filter((v) => !venue.virtual_ids.includes(v.id))
 

--- a/src/pages/Venues/VenueView.tsx
+++ b/src/pages/Venues/VenueView.tsx
@@ -75,7 +75,7 @@ export default function VenueView({ venue, onLeave }: Props) {
       <Typography variant="subtitle1" gutterBottom>
         Color Override Pads
       </Typography>
-      <ColorPadGrid venue={venue} />
+      <ColorPadGrid venue={venue} isEditMode={false} />
 
       <Divider sx={{ my: 3 }} />
 

--- a/src/pages/Venues/VenueView.tsx
+++ b/src/pages/Venues/VenueView.tsx
@@ -1,0 +1,113 @@
+import { useCallback, useState } from 'react'
+import {
+  Box,
+  Button,
+  Chip,
+  Typography,
+  Divider,
+  Autocomplete,
+  TextField
+} from '@mui/material'
+import { ArrowBack } from '@mui/icons-material'
+import useStore from '../../store/useStore'
+import type { Venue } from '../../store/api/storeVenues'
+import ColorPadGrid from './ColorPadGrid'
+
+interface Props {
+  venue: Venue
+  onLeave: () => void
+}
+
+export default function VenueView({ venue, onLeave }: Props) {
+  const virtuals = useStore((state) => state.virtuals)
+  const venues = useStore((state) => state.venues)
+  const addVirtualToVenue = useStore((state) => state.addVirtualToVenue)
+  const removeVirtualFromVenue = useStore((state) => state.removeVirtualFromVenue)
+  const [adding, setAdding] = useState(false)
+
+  // Compute which virtual IDs are already in ANY venue (for greying-out in picker)
+  const occupiedVirtualIds = Object.values(venues).reduce<Set<string>>((acc, v) => {
+    for (const vid of v.virtual_ids) acc.add(vid)
+    return acc
+  }, new Set())
+
+  // Virtual options for autocomplete: exclude those already in another venue
+  const availableVirtuals = Object.values(virtuals).filter(
+    (v) => !occupiedVirtualIds.has(v.id) || venue.virtual_ids.includes(v.id)
+  )
+
+  const handleAddVirtual = useCallback(
+    async (_: any, newValue: any) => {
+      if (!newValue) return
+      setAdding(true)
+      await addVirtualToVenue(venue.id, newValue.id)
+      setAdding(false)
+    },
+    [venue.id, addVirtualToVenue]
+  )
+
+  const handleRemoveVirtual = useCallback(
+    async (virtualId: string) => {
+      await removeVirtualFromVenue(venue.id, virtualId)
+    },
+    [venue.id, removeVirtualFromVenue]
+  )
+
+  const memberVirtuals = venue.virtual_ids
+    .map((id) => virtuals[id])
+    .filter(Boolean)
+
+  const notYetAdded = availableVirtuals.filter((v) => !venue.virtual_ids.includes(v.id))
+
+  return (
+    <Box sx={{ p: 2 }}>
+      {/* Header */}
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 2 }}>
+        <Button startIcon={<ArrowBack />} onClick={onLeave} variant="outlined" size="small">
+          All Venues
+        </Button>
+        <Typography variant="h5">{venue.name}</Typography>
+      </Box>
+
+      <Divider sx={{ mb: 2 }} />
+
+      {/* Color Override Pad Grid */}
+      <Typography variant="subtitle1" gutterBottom>
+        Color Override Pads
+      </Typography>
+      <ColorPadGrid venue={venue} />
+
+      <Divider sx={{ my: 3 }} />
+
+      {/* Virtual membership */}
+      <Typography variant="subtitle1" gutterBottom>
+        Virtuals in this venue
+      </Typography>
+      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mb: 2 }}>
+        {memberVirtuals.length === 0 && (
+          <Typography color="text.secondary" variant="body2">
+            No virtuals assigned yet.
+          </Typography>
+        )}
+        {memberVirtuals.map((v) => (
+          <Chip
+            key={v.id}
+            label={v.config?.name ?? v.id}
+            onDelete={() => handleRemoveVirtual(v.id)}
+          />
+        ))}
+      </Box>
+      <Autocomplete
+        options={notYetAdded}
+        getOptionLabel={(v) => v.config?.name ?? v.id}
+        onChange={handleAddVirtual}
+        value={null}
+        disabled={adding}
+        renderInput={(params) => (
+          <TextField {...params} label="Add virtual to venue" size="small" sx={{ maxWidth: 320 }} />
+        )}
+        isOptionEqualToValue={(a, b) => a.id === b.id}
+      />
+    </Box>
+  )
+}

--- a/src/pages/Venues/VenueViewPage.tsx
+++ b/src/pages/Venues/VenueViewPage.tsx
@@ -47,6 +47,7 @@ export default function VenueViewPage() {
     return () => {
       setPixelGraphs([])
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only re-subscribe when virtual_ids actually change
   }, [venue?.virtual_ids, setPixelGraphs])
 
   const handleBack = useCallback(async () => {
@@ -155,9 +156,20 @@ export default function VenueViewPage() {
                     {v.config?.name ?? v.id}
                   </Typography>
                   {effectName ? (
-                    <Chip label={effectName} size="small" variant="outlined" sx={{ height: 18, fontSize: '0.65rem' }} />
+                    <Chip
+                      label={effectName}
+                      size="small"
+                      variant="outlined"
+                      sx={{ height: 18, fontSize: '0.65rem' }}
+                    />
                   ) : (
-                    <Chip label="No effect" size="small" variant="outlined" color="default" sx={{ height: 18, fontSize: '0.65rem', opacity: 0.5 }} />
+                    <Chip
+                      label="No effect"
+                      size="small"
+                      variant="outlined"
+                      color="default"
+                      sx={{ height: 18, fontSize: '0.65rem', opacity: 0.5 }}
+                    />
                   )}
                 </Box>
                 <PixelGraph virtId={v.id} active={v.active} db />

--- a/src/pages/Venues/VenueViewPage.tsx
+++ b/src/pages/Venues/VenueViewPage.tsx
@@ -11,9 +11,10 @@ import {
   CircularProgress,
   ToggleButton
 } from '@mui/material'
-import { ArrowBack, Edit, EditOff } from '@mui/icons-material'
+import { ArrowBack, Edit, EditOff, FlashOn } from '@mui/icons-material'
 import useStore from '../../store/useStore'
 import ColorPadGrid from './ColorPadGrid'
+import PixelGraph from '../../components/PixelGraph/PixelGraph'
 
 export default function VenueViewPage() {
   const { venueId } = useParams<{ venueId: string }>()
@@ -26,6 +27,9 @@ export default function VenueViewPage() {
   const addVirtualToVenue = useStore((state) => state.addVirtualToVenue)
   const removeVirtualFromVenue = useStore((state) => state.removeVirtualFromVenue)
   const clearVenueOverride = useStore((state) => state.clearVenueOverride)
+  const setPixelGraphs = useStore((state) => state.setPixelGraphs)
+  const activeVenueId = useStore((state) => state.activeVenueId)
+  const activeOverridePadIndex = useStore((state) => state.activeOverridePadIndex)
 
   const [adding, setAdding] = useState(false)
   const [isEditMode, setIsEditMode] = useState(false)
@@ -35,6 +39,15 @@ export default function VenueViewPage() {
       getVenues()
     }
   }, [venue, getVenues])
+
+  // Subscribe to WebSocket pixel updates for all venue virtuals
+  useEffect(() => {
+    if (!venue) return
+    setPixelGraphs(venue.virtual_ids)
+    return () => {
+      setPixelGraphs([])
+    }
+  }, [venue?.virtual_ids, setPixelGraphs])
 
   const handleBack = useCallback(async () => {
     if (venueId) await clearVenueOverride(venueId)
@@ -67,6 +80,8 @@ export default function VenueViewPage() {
       </Box>
     )
   }
+
+  const overrideActive = activeVenueId === venueId && activeOverridePadIndex !== null
 
   const occupiedVirtualIds = Object.values(venues).reduce<Set<string>>((acc, v) => {
     for (const vid of v.virtual_ids) acc.add(vid)
@@ -109,6 +124,48 @@ export default function VenueViewPage() {
         </ToggleButton>
       </Box>
       <ColorPadGrid venue={venue} isEditMode={isEditMode} />
+
+      <Divider sx={{ my: 3 }} />
+
+      {/* Live Preview */}
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+        <Typography variant="subtitle1">Live Preview</Typography>
+        {overrideActive && (
+          <Chip
+            icon={<FlashOn fontSize="small" />}
+            label="Override Active"
+            size="small"
+            color="warning"
+            variant="outlined"
+          />
+        )}
+      </Box>
+      {memberVirtuals.length === 0 ? (
+        <Typography color="text.secondary" variant="body2" sx={{ mb: 1 }}>
+          Add virtuals to see a live preview.
+        </Typography>
+      ) : (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, mb: 1 }}>
+          {memberVirtuals.map((v) => {
+            const effectName = v.effect?.name ?? v.effect?.type ?? null
+            return (
+              <Box key={v.id}>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5 }}>
+                  <Typography variant="caption" color="text.secondary">
+                    {v.config?.name ?? v.id}
+                  </Typography>
+                  {effectName ? (
+                    <Chip label={effectName} size="small" variant="outlined" sx={{ height: 18, fontSize: '0.65rem' }} />
+                  ) : (
+                    <Chip label="No effect" size="small" variant="outlined" color="default" sx={{ height: 18, fontSize: '0.65rem', opacity: 0.5 }} />
+                  )}
+                </Box>
+                <PixelGraph virtId={v.id} active={v.active} db />
+              </Box>
+            )
+          })}
+        </Box>
+      )}
 
       <Divider sx={{ my: 3 }} />
 

--- a/src/pages/Venues/VenueViewPage.tsx
+++ b/src/pages/Venues/VenueViewPage.tsx
@@ -1,0 +1,146 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
+import {
+  Box,
+  Button,
+  Chip,
+  Typography,
+  Divider,
+  Autocomplete,
+  TextField,
+  CircularProgress,
+  ToggleButton
+} from '@mui/material'
+import { ArrowBack, Edit, EditOff } from '@mui/icons-material'
+import useStore from '../../store/useStore'
+import ColorPadGrid from './ColorPadGrid'
+
+export default function VenueViewPage() {
+  const { venueId } = useParams<{ venueId: string }>()
+  const navigate = useNavigate()
+
+  const venue = useStore((state) => (venueId ? state.venues[venueId] : undefined))
+  const virtuals = useStore((state) => state.virtuals)
+  const venues = useStore((state) => state.venues)
+  const getVenues = useStore((state) => state.getVenues)
+  const addVirtualToVenue = useStore((state) => state.addVirtualToVenue)
+  const removeVirtualFromVenue = useStore((state) => state.removeVirtualFromVenue)
+  const clearVenueOverride = useStore((state) => state.clearVenueOverride)
+
+  const [adding, setAdding] = useState(false)
+  const [isEditMode, setIsEditMode] = useState(false)
+
+  useEffect(() => {
+    if (!venue) {
+      getVenues()
+    }
+  }, [venue, getVenues])
+
+  const handleBack = useCallback(async () => {
+    if (venueId) await clearVenueOverride(venueId)
+    navigate('/venues')
+  }, [venueId, clearVenueOverride, navigate])
+
+  const handleAddVirtual = useCallback(
+    async (_: any, newValue: any) => {
+      if (!newValue || !venueId) return
+      setAdding(true)
+      await addVirtualToVenue(venueId, newValue.id)
+      setAdding(false)
+    },
+    [venueId, addVirtualToVenue]
+  )
+
+  const handleRemoveVirtual = useCallback(
+    async (virtualId: string) => {
+      if (!venueId) return
+      await removeVirtualFromVenue(venueId, virtualId)
+    },
+    [venueId, removeVirtualFromVenue]
+  )
+
+  if (!venue) {
+    return (
+      <Box sx={{ p: 2, display: 'flex', alignItems: 'center', gap: 2 }}>
+        <CircularProgress size={20} />
+        <Typography>Loading venue…</Typography>
+      </Box>
+    )
+  }
+
+  const occupiedVirtualIds = Object.values(venues).reduce<Set<string>>((acc, v) => {
+    for (const vid of v.virtual_ids) acc.add(vid)
+    return acc
+  }, new Set())
+
+  const availableVirtuals = Object.values(virtuals).filter(
+    (v) => !occupiedVirtualIds.has(v.id) || venue.virtual_ids.includes(v.id)
+  )
+
+  const memberVirtuals = venue.virtual_ids.map((id) => virtuals[id]).filter(Boolean)
+  const notYetAdded = availableVirtuals.filter((v) => !venue.virtual_ids.includes(v.id))
+
+  return (
+    <Box sx={{ p: 2 }}>
+      {/* Header */}
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 2 }}>
+        <Button startIcon={<ArrowBack />} onClick={handleBack} variant="outlined" size="small">
+          All Venues
+        </Button>
+        <Typography variant="h5">{venue.name}</Typography>
+      </Box>
+
+      <Divider sx={{ mb: 2 }} />
+
+      {/* Color Override Pad Grid */}
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 1 }}>
+        <Typography variant="subtitle1">Color Override Pads</Typography>
+        <ToggleButton
+          value="edit"
+          selected={isEditMode}
+          onChange={() => setIsEditMode((v) => !v)}
+          size="small"
+          color="primary"
+        >
+          {isEditMode ? <EditOff fontSize="small" /> : <Edit fontSize="small" />}
+          <Box component="span" sx={{ ml: 0.5, fontSize: '0.75rem' }}>
+            {isEditMode ? 'Done' : 'Edit Grid'}
+          </Box>
+        </ToggleButton>
+      </Box>
+      <ColorPadGrid venue={venue} isEditMode={isEditMode} />
+
+      <Divider sx={{ my: 3 }} />
+
+      {/* Virtual membership */}
+      <Typography variant="subtitle1" gutterBottom>
+        Virtuals in this venue
+      </Typography>
+      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mb: 2 }}>
+        {memberVirtuals.length === 0 && (
+          <Typography color="text.secondary" variant="body2">
+            No virtuals assigned yet.
+          </Typography>
+        )}
+        {memberVirtuals.map((v) => (
+          <Chip
+            key={v.id}
+            label={v.config?.name ?? v.id}
+            onDelete={() => handleRemoveVirtual(v.id)}
+          />
+        ))}
+      </Box>
+      <Autocomplete
+        options={notYetAdded}
+        getOptionLabel={(v) => v.config?.name ?? v.id}
+        onChange={handleAddVirtual}
+        value={null}
+        disabled={adding}
+        renderInput={(params) => (
+          <TextField {...params} label="Add virtual to venue" size="small" sx={{ maxWidth: 320 }} />
+        )}
+        isOptionEqualToValue={(a, b) => a.id === b.id}
+      />
+    </Box>
+  )
+}

--- a/src/pages/Venues/VenuesPage.tsx
+++ b/src/pages/Venues/VenuesPage.tsx
@@ -1,0 +1,239 @@
+import { useState, useEffect, useCallback } from 'react'
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  CardActions,
+  Typography,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  IconButton,
+  Tooltip
+} from '@mui/material'
+import { Add, Delete, Edit, MeetingRoom } from '@mui/icons-material'
+import useStore from '../../store/useStore'
+import VenueView from './VenueView'
+
+interface CreateVenueDialogProps {
+  open: boolean
+  onClose: () => void
+  onSave: (name: string, rows: number, cols: number) => void
+  initial?: { name: string; rows: number; cols: number }
+}
+
+function CreateVenueDialog({ open, onClose, onSave, initial }: CreateVenueDialogProps) {
+  const [name, setName] = useState(initial?.name ?? '')
+  const [rows, setRows] = useState(initial?.rows ?? 4)
+  const [cols, setCols] = useState(initial?.cols ?? 4)
+
+  useEffect(() => {
+    if (open) {
+      setName(initial?.name ?? '')
+      setRows(initial?.rows ?? 4)
+      setCols(initial?.cols ?? 4)
+    }
+  }, [open, initial?.name, initial?.rows, initial?.cols])
+
+  const handleSave = () => {
+    if (!name.trim()) return
+    onSave(name.trim(), rows, cols)
+    onClose()
+  }
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle>{initial ? 'Edit Venue' : 'Create Venue'}</DialogTitle>
+      <DialogContent>
+        <TextField
+          autoFocus
+          label="Venue name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          fullWidth
+          margin="dense"
+        />
+        <Box sx={{ display: 'flex', gap: 2, mt: 2 }}>
+          <TextField
+            label="Override pad rows"
+            type="number"
+            value={rows}
+            onChange={(e) => setRows(Math.max(1, parseInt(e.target.value) || 1))}
+            slotProps={{ htmlInput: { min: 1, max: 16 } }}
+            size="small"
+          />
+          <TextField
+            label="Override pad cols"
+            type="number"
+            value={cols}
+            onChange={(e) => setCols(Math.max(1, parseInt(e.target.value) || 1))}
+            slotProps={{ htmlInput: { min: 1, max: 16 } }}
+            size="small"
+          />
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button onClick={handleSave} variant="contained" disabled={!name.trim()}>
+          {initial ? 'Save' : 'Create'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}
+
+export default function VenuesPage() {
+  const venues = useStore((state) => state.venues)
+  const activeVenueId = useStore((state) => state.activeVenueId)
+  const getVenues = useStore((state) => state.getVenues)
+  const createVenue = useStore((state) => state.createVenue)
+  const updateVenue = useStore((state) => state.updateVenue)
+  const deleteVenue = useStore((state) => state.deleteVenue)
+  const setActiveVenueId = useStore((state) => state.setActiveVenueId)
+  const clearVenueOverride = useStore((state) => state.clearVenueOverride)
+
+  const [createOpen, setCreateOpen] = useState(false)
+  const [editVenue, setEditVenue] = useState<{ id: string; name: string; rows: number; cols: number } | null>(null)
+
+  useEffect(() => {
+    getVenues()
+  }, [getVenues])
+
+  const handleCreate = useCallback(
+    async (name: string, rows: number, cols: number) => {
+      await createVenue(name, rows, cols)
+    },
+    [createVenue]
+  )
+
+  const handleEdit = useCallback(
+    async (name: string, rows: number, cols: number) => {
+      if (!editVenue) return
+      await updateVenue(editVenue.id, {
+        name,
+        color_pads: { ...venues[editVenue.id]?.color_pads, rows, cols }
+      })
+      setEditVenue(null)
+    },
+    [editVenue, updateVenue, venues]
+  )
+
+  const handleDelete = useCallback(
+    async (venueId: string) => {
+      if (activeVenueId === venueId) {
+        await clearVenueOverride(venueId)
+        setActiveVenueId(null)
+      }
+      await deleteVenue(venueId)
+    },
+    [activeVenueId, clearVenueOverride, setActiveVenueId, deleteVenue]
+  )
+
+  const handleEnter = useCallback(
+    (venueId: string) => {
+      setActiveVenueId(venueId)
+    },
+    [setActiveVenueId]
+  )
+
+  const handleLeave = useCallback(async () => {
+    if (activeVenueId) {
+      await clearVenueOverride(activeVenueId)
+    }
+    setActiveVenueId(null)
+  }, [activeVenueId, clearVenueOverride, setActiveVenueId])
+
+  if (activeVenueId && venues[activeVenueId]) {
+    return <VenueView venue={venues[activeVenueId]} onLeave={handleLeave} />
+  }
+
+  const venueList = Object.values(venues)
+
+  return (
+    <Box sx={{ p: 2 }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', mb: 2, gap: 2 }}>
+        <Typography variant="h5">Venues</Typography>
+        <Button
+          variant="contained"
+          startIcon={<Add />}
+          onClick={() => setCreateOpen(true)}
+          size="small"
+        >
+          New Venue
+        </Button>
+      </Box>
+
+      {venueList.length === 0 ? (
+        <Typography color="text.secondary">
+          No venues yet. Create one to group your devices and use color override pads.
+        </Typography>
+      ) : (
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2 }}>
+          {venueList.map((venue) => (
+            <Box key={venue.id} sx={{ minWidth: 240, maxWidth: 320, flex: '1 1 240px' }}>
+              <Card>
+                <CardContent>
+                  <Typography variant="h6">{venue.name}</Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    {venue.virtual_ids.length} virtual
+                    {venue.virtual_ids.length !== 1 ? 's' : ''}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    {venue.color_pads.rows}×{venue.color_pads.cols} override pad grid
+                  </Typography>
+                </CardContent>
+                <CardActions>
+                  <Button
+                    size="small"
+                    variant="contained"
+                    startIcon={<MeetingRoom />}
+                    onClick={() => handleEnter(venue.id)}
+                  >
+                    Enter
+                  </Button>
+                  <Tooltip title="Edit">
+                    <IconButton
+                      size="small"
+                      onClick={() =>
+                        setEditVenue({
+                          id: venue.id,
+                          name: venue.name,
+                          rows: venue.color_pads.rows,
+                          cols: venue.color_pads.cols
+                        })
+                      }
+                    >
+                      <Edit fontSize="small" />
+                    </IconButton>
+                  </Tooltip>
+                  <Tooltip title="Delete">
+                    <IconButton size="small" onClick={() => handleDelete(venue.id)}>
+                      <Delete fontSize="small" />
+                    </IconButton>
+                  </Tooltip>
+                </CardActions>
+              </Card>
+            </Box>
+          ))}
+        </Box>
+      )}
+
+      <CreateVenueDialog
+        open={createOpen}
+        onClose={() => setCreateOpen(false)}
+        onSave={handleCreate}
+      />
+      {editVenue && (
+        <CreateVenueDialog
+          open={!!editVenue}
+          onClose={() => setEditVenue(null)}
+          onSave={handleEdit}
+          initial={editVenue}
+        />
+      )}
+    </Box>
+  )
+}

--- a/src/pages/Venues/VenuesPage.tsx
+++ b/src/pages/Venues/VenuesPage.tsx
@@ -94,7 +94,12 @@ export default function VenuesPage() {
   const navigate = useNavigate()
 
   const [createOpen, setCreateOpen] = useState(false)
-  const [editVenue, setEditVenue] = useState<{ id: string; name: string; rows: number; cols: number } | null>(null)
+  const [editVenue, setEditVenue] = useState<{
+    id: string
+    name: string
+    rows: number
+    cols: number
+  } | null>(null)
 
   useEffect(() => {
     getVenues()

--- a/src/pages/Venues/VenuesPage.tsx
+++ b/src/pages/Venues/VenuesPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
 import {
   Box,
   Button,
@@ -16,7 +17,6 @@ import {
 } from '@mui/material'
 import { Add, Delete, Edit, MeetingRoom } from '@mui/icons-material'
 import useStore from '../../store/useStore'
-import VenueView from './VenueView'
 
 interface CreateVenueDialogProps {
   open: boolean
@@ -87,13 +87,11 @@ function CreateVenueDialog({ open, onClose, onSave, initial }: CreateVenueDialog
 
 export default function VenuesPage() {
   const venues = useStore((state) => state.venues)
-  const activeVenueId = useStore((state) => state.activeVenueId)
   const getVenues = useStore((state) => state.getVenues)
   const createVenue = useStore((state) => state.createVenue)
   const updateVenue = useStore((state) => state.updateVenue)
   const deleteVenue = useStore((state) => state.deleteVenue)
-  const setActiveVenueId = useStore((state) => state.setActiveVenueId)
-  const clearVenueOverride = useStore((state) => state.clearVenueOverride)
+  const navigate = useNavigate()
 
   const [createOpen, setCreateOpen] = useState(false)
   const [editVenue, setEditVenue] = useState<{ id: string; name: string; rows: number; cols: number } | null>(null)
@@ -123,32 +121,17 @@ export default function VenuesPage() {
 
   const handleDelete = useCallback(
     async (venueId: string) => {
-      if (activeVenueId === venueId) {
-        await clearVenueOverride(venueId)
-        setActiveVenueId(null)
-      }
       await deleteVenue(venueId)
     },
-    [activeVenueId, clearVenueOverride, setActiveVenueId, deleteVenue]
+    [deleteVenue]
   )
 
   const handleEnter = useCallback(
     (venueId: string) => {
-      setActiveVenueId(venueId)
+      navigate('/venues/' + venueId)
     },
-    [setActiveVenueId]
+    [navigate]
   )
-
-  const handleLeave = useCallback(async () => {
-    if (activeVenueId) {
-      await clearVenueOverride(activeVenueId)
-    }
-    setActiveVenueId(null)
-  }, [activeVenueId, clearVenueOverride, setActiveVenueId])
-
-  if (activeVenueId && venues[activeVenueId]) {
-    return <VenueView venue={venues[activeVenueId]} onLeave={handleLeave} />
-  }
 
   const venueList = Object.values(venues)
 

--- a/src/store/api/storeVenues.tsx
+++ b/src/store/api/storeVenues.tsx
@@ -210,4 +210,3 @@ const storeVenues = (set: any) => ({
 })
 
 export default storeVenues
-

--- a/src/store/api/storeVenues.tsx
+++ b/src/store/api/storeVenues.tsx
@@ -160,6 +160,7 @@ const storeVenues = (set: any) => ({
     if (resp) {
       set(
         produce((s: IStore) => {
+          s.activeVenueId = venueId
           s.activeOverridePadIndex = padIndex
         }),
         false,
@@ -175,6 +176,7 @@ const storeVenues = (set: any) => ({
     if (resp) {
       set(
         produce((s: IStore) => {
+          s.activeVenueId = null
           s.activeOverridePadIndex = null
         }),
         false,

--- a/src/store/api/storeVenues.tsx
+++ b/src/store/api/storeVenues.tsx
@@ -66,30 +66,32 @@ const storeVenues = (set: any) => ({
 
   createVenue: async (name: string, rows = 4, cols = 4) => {
     const resp = await Ledfx('/api/venues', 'POST', { name, rows, cols })
-    if (resp && resp.venue) {
+    const venue = resp?.data?.venue
+    if (venue) {
       set(
         produce((s: IStore) => {
-          s.venues[resp.venue.id] = resp.venue
+          s.venues[venue.id] = venue
         }),
         false,
         'venues/created'
       )
-      return resp.venue as Venue
+      return venue as Venue
     }
     return null
   },
 
   updateVenue: async (venueId: string, data: Partial<Pick<Venue, 'name' | 'color_pads'>>) => {
     const resp = await Ledfx(`/api/venues/${venueId}`, 'PUT', data)
-    if (resp && resp.venue) {
+    const venue = resp?.data?.venue
+    if (venue) {
       set(
         produce((s: IStore) => {
-          s.venues[venueId] = resp.venue
+          s.venues[venueId] = venue
         }),
         false,
         'venues/updated'
       )
-      return resp.venue as Venue
+      return venue as Venue
     }
     return null
   },
@@ -118,15 +120,16 @@ const storeVenues = (set: any) => ({
       action: 'add_virtual',
       virtual_id: virtualId
     })
-    if (resp && resp.venue) {
+    const venue = resp?.data?.venue
+    if (venue) {
       set(
         produce((s: IStore) => {
-          s.venues[venueId] = resp.venue
+          s.venues[venueId] = venue
         }),
         false,
         'venues/addedVirtual'
       )
-      return resp.venue as Venue
+      return venue as Venue
     }
     return null
   },
@@ -136,15 +139,16 @@ const storeVenues = (set: any) => ({
       action: 'remove_virtual',
       virtual_id: virtualId
     })
-    if (resp && resp.venue) {
+    const venue = resp?.data?.venue
+    if (venue) {
       set(
         produce((s: IStore) => {
-          s.venues[venueId] = resp.venue
+          s.venues[venueId] = venue
         }),
         false,
         'venues/removedVirtual'
       )
-      return resp.venue as Venue
+      return venue as Venue
     }
     return null
   },
@@ -188,15 +192,16 @@ const storeVenues = (set: any) => ({
     updatedPads[padIndex] = pad
     const updatedColorPads = { ...currentVenue.color_pads, pads: updatedPads }
     const resp = await Ledfx(`/api/venues/${venueId}`, 'PUT', { color_pads: updatedColorPads })
-    if (resp && resp.venue) {
+    const venue = resp?.data?.venue
+    if (venue) {
       set(
         produce((s: IStore) => {
-          s.venues[venueId] = resp.venue
+          s.venues[venueId] = venue
         }),
         false,
         'venues/padUpdated'
       )
-      return resp.venue as Venue
+      return venue as Venue
     }
     return null
   }

--- a/src/store/api/storeVenues.tsx
+++ b/src/store/api/storeVenues.tsx
@@ -1,0 +1,206 @@
+import { produce } from 'immer'
+import { Ledfx } from '../../api/ledfx'
+import type { IStore } from '../useStore'
+import useStore from '../useStore'
+
+export interface ColorPad {
+  color?: string
+  gradient?: string
+}
+
+export interface VenueColorPads {
+  rows: number
+  cols: number
+  pads: ColorPad[]
+}
+
+export interface Venue {
+  id: string
+  name: string
+  virtual_ids: string[]
+  color_pads: VenueColorPads
+}
+
+const storeVenues = (set: any) => ({
+  venues: {} as Record<string, Venue>,
+  activeVenueId: null as string | null,
+  activeOverridePadIndex: null as number | null,
+
+  setActiveVenueId: (id: string | null) =>
+    set(
+      produce((s: IStore) => {
+        s.activeVenueId = id
+        s.activeOverridePadIndex = null
+      }),
+      false,
+      'venues/setActiveVenueId'
+    ),
+
+  setActiveOverridePadIndex: (index: number | null) =>
+    set(
+      produce((s: IStore) => {
+        s.activeOverridePadIndex = index
+      }),
+      false,
+      'venues/setActiveOverridePadIndex'
+    ),
+
+  getVenues: async () => {
+    const resp = await Ledfx('/api/venues')
+    if (resp && resp.venues) {
+      const byId: Record<string, Venue> = {}
+      for (const v of resp.venues) {
+        byId[v.id] = v
+      }
+      set(
+        produce((s: IStore) => {
+          s.venues = byId
+        }),
+        false,
+        'venues/gotVenues'
+      )
+      return byId
+    }
+    return null
+  },
+
+  createVenue: async (name: string, rows = 4, cols = 4) => {
+    const resp = await Ledfx('/api/venues', 'POST', { name, rows, cols })
+    if (resp && resp.venue) {
+      set(
+        produce((s: IStore) => {
+          s.venues[resp.venue.id] = resp.venue
+        }),
+        false,
+        'venues/created'
+      )
+      return resp.venue as Venue
+    }
+    return null
+  },
+
+  updateVenue: async (venueId: string, data: Partial<Pick<Venue, 'name' | 'color_pads'>>) => {
+    const resp = await Ledfx(`/api/venues/${venueId}`, 'PUT', data)
+    if (resp && resp.venue) {
+      set(
+        produce((s: IStore) => {
+          s.venues[venueId] = resp.venue
+        }),
+        false,
+        'venues/updated'
+      )
+      return resp.venue as Venue
+    }
+    return null
+  },
+
+  deleteVenue: async (venueId: string) => {
+    const resp = await Ledfx(`/api/venues/${venueId}`, 'DELETE')
+    if (resp) {
+      set(
+        produce((s: IStore) => {
+          delete s.venues[venueId]
+          if (s.activeVenueId === venueId) {
+            s.activeVenueId = null
+            s.activeOverridePadIndex = null
+          }
+        }),
+        false,
+        'venues/deleted'
+      )
+      return true
+    }
+    return false
+  },
+
+  addVirtualToVenue: async (venueId: string, virtualId: string) => {
+    const resp = await Ledfx(`/api/venues/${venueId}`, 'PUT', {
+      action: 'add_virtual',
+      virtual_id: virtualId
+    })
+    if (resp && resp.venue) {
+      set(
+        produce((s: IStore) => {
+          s.venues[venueId] = resp.venue
+        }),
+        false,
+        'venues/addedVirtual'
+      )
+      return resp.venue as Venue
+    }
+    return null
+  },
+
+  removeVirtualFromVenue: async (venueId: string, virtualId: string) => {
+    const resp = await Ledfx(`/api/venues/${venueId}`, 'PUT', {
+      action: 'remove_virtual',
+      virtual_id: virtualId
+    })
+    if (resp && resp.venue) {
+      set(
+        produce((s: IStore) => {
+          s.venues[venueId] = resp.venue
+        }),
+        false,
+        'venues/removedVirtual'
+      )
+      return resp.venue as Venue
+    }
+    return null
+  },
+
+  activateVenueOverride: async (venueId: string, padIndex: number) => {
+    const resp = await Ledfx(`/api/venues/${venueId}/override`, 'POST', {
+      pad_index: padIndex
+    })
+    if (resp) {
+      set(
+        produce((s: IStore) => {
+          s.activeOverridePadIndex = padIndex
+        }),
+        false,
+        'venues/overrideActivated'
+      )
+      return true
+    }
+    return false
+  },
+
+  clearVenueOverride: async (venueId: string) => {
+    const resp = await Ledfx(`/api/venues/${venueId}/override`, 'DELETE')
+    if (resp) {
+      set(
+        produce((s: IStore) => {
+          s.activeOverridePadIndex = null
+        }),
+        false,
+        'venues/overrideCleared'
+      )
+      return true
+    }
+    return false
+  },
+
+  updateVenuePad: async (venueId: string, padIndex: number, pad: ColorPad) => {
+    const currentVenue = useStore.getState().venues[venueId]
+    if (!currentVenue) return null
+    const updatedPads = [...currentVenue.color_pads.pads]
+    updatedPads[padIndex] = pad
+    const updatedColorPads = { ...currentVenue.color_pads, pads: updatedPads }
+    const resp = await Ledfx(`/api/venues/${venueId}`, 'PUT', { color_pads: updatedColorPads })
+    if (resp && resp.venue) {
+      set(
+        produce((s: IStore) => {
+          s.venues[venueId] = resp.venue
+        }),
+        false,
+        'venues/padUpdated'
+      )
+      return resp.venue as Venue
+    }
+    return null
+  }
+})
+
+export default storeVenues
+

--- a/src/store/ui/storeDmxInput.tsx
+++ b/src/store/ui/storeDmxInput.tsx
@@ -1,0 +1,26 @@
+export interface DmxMapping {
+  name?: string
+  type: 'trigger' | 'color' | 'fixture'
+  universe: number
+  channels: number[] | Record<string, number>
+  venue_id?: string
+  pad_index?: number
+  virtual_id?: string
+  on_threshold?: number
+  off_threshold?: number
+  active?: boolean
+}
+
+export interface DmxInputData {
+  mappings: DmxMapping[]
+  live_dmx: Record<string, number[]>
+  venues: Record<string, any>
+  virtuals: Record<string, string>
+}
+
+const storeDmxInput = () => ({
+  // keyed by integration id
+  dmxInput: {} as Record<string, DmxInputData>
+})
+
+export default storeDmxInput

--- a/src/store/ui/storeDmxInput.tsx
+++ b/src/store/ui/storeDmxInput.tsx
@@ -9,6 +9,15 @@ export interface DmxMapping {
   on_threshold?: number
   off_threshold?: number
   active?: boolean
+  /** Fixture-wash only: probability (0-1) that a detected strobe pulse
+   * actually renders instead of being forced black; 1 = every pulse
+   * renders (today's default, no desync from real fixtures simulated). */
+  strobe_probability?: number
+  /** Frontend-only bookkeeping: remembers each mapping type's last-entered
+   * field values (channels/thresholds/target/strobe settings) so switching
+   * a mapping's type in the editor re-populates previous values instead of
+   * resetting to schema defaults. Opaque to the backend, persisted as-is. */
+  _type_field_cache?: Record<string, Record<string, unknown>>
 }
 
 export interface DmxInputData {

--- a/src/store/ui/storeDmxInputActions.tsx
+++ b/src/store/ui/storeDmxInputActions.tsx
@@ -1,0 +1,67 @@
+import { produce } from 'immer'
+import { Ledfx } from '../../api/ledfx'
+import type { IStore } from '../useStore'
+import type { DmxInputData, DmxMapping } from './storeDmxInput'
+
+const storeDmxInputActions = (set: any) => ({
+  getDmxInput: async (integrationId: string) => {
+    const resp = await Ledfx(`/api/integrations/dmx_input/${integrationId}`)
+    if (resp && resp.mappings !== undefined) {
+      set(
+        produce((state: IStore) => {
+          state.dmxInput[integrationId] = {
+            mappings: resp.mappings || [],
+            live_dmx: resp.live_dmx || {},
+            venues: resp.venues || {},
+            virtuals: resp.virtuals || {}
+          } as DmxInputData
+        }),
+        false,
+        'dmxInput/get'
+      )
+      return resp as DmxInputData
+    }
+    return null
+  },
+
+  // Lightweight poll used by the live monitor / DMX-learn (only updates live_dmx)
+  getDmxLive: async (integrationId: string) => {
+    const resp = await Ledfx(
+      `/api/integrations/dmx_input/${integrationId}`,
+      'GET',
+      undefined,
+      false
+    )
+    if (resp && resp.live_dmx !== undefined) {
+      set(
+        produce((state: IStore) => {
+          if (!state.dmxInput[integrationId]) {
+            state.dmxInput[integrationId] = {
+              mappings: resp.mappings || [],
+              live_dmx: resp.live_dmx || {},
+              venues: resp.venues || {},
+              virtuals: resp.virtuals || {}
+            } as DmxInputData
+          } else {
+            state.dmxInput[integrationId].live_dmx = resp.live_dmx || {}
+          }
+        }),
+        false,
+        'dmxInput/getLive'
+      )
+      return resp.live_dmx as Record<string, number[]>
+    }
+    return null
+  },
+
+  saveDmxMapping: async (integrationId: string, mapping: DmxMapping, index?: number) =>
+    Ledfx(`/api/integrations/dmx_input/${integrationId}`, 'POST', {
+      mapping,
+      ...(index !== undefined && index !== null ? { index } : {})
+    }),
+
+  deleteDmxMapping: async (integrationId: string, index: number) =>
+    Ledfx(`/api/integrations/dmx_input/${integrationId}`, 'DELETE', { data: { index } })
+})
+
+export default storeDmxInputActions

--- a/src/store/useStore.ts
+++ b/src/store/useStore.ts
@@ -9,6 +9,7 @@ import storeUser from './ui/storeUser'
 import storeDialogs from './ui/storeDialogs'
 import storeSpotify from './ui/storeSpotify'
 import storeQLC from './ui/storeQLC'
+import storeDmxInput from './ui/storeDmxInput'
 import storeWebAudio from './ui/storeWebAudio'
 import storeCloud from './ui/storeCloud'
 import storeDevices from './api/storeDevices'
@@ -22,6 +23,7 @@ import storeActions from './api/storeActions'
 import storeColors from './api/storeColors'
 import storeSpotifyActions from './ui/storeSpotifyActions'
 import storeQLCActions from './ui/storeQLCActions'
+import storeDmxInputActions from './ui/storeDmxInputActions'
 import storeNotifications from './ui/storeNotifications'
 import storePad from './ui/storePad'
 import storeMidi from './ui/storeMidi'
@@ -52,6 +54,7 @@ const useStore = create(
           uiPersist: storeUIPersist(),
           spotify: storeSpotify(),
           qlc: storeQLC(),
+          ...storeDmxInput(),
           user: storeUser(set),
           ...storeMatrix(set),
           ...storeUIPersistActions(set),
@@ -62,6 +65,7 @@ const useStore = create(
           ...storeTours(set),
           ...storeSpotifyActions(set),
           ...storeQLCActions(set),
+          ...storeDmxInputActions(set),
           ...storeGeneral(set),
           ...storeDialogs(set),
           ...storeFeatures(set),
@@ -113,7 +117,8 @@ const useStore = create(
                   'externalStudioRef',
                   'clientIdentity',
                   'activeVenueId',
-                  'activeOverridePadIndex'
+                  'activeOverridePadIndex',
+                  'dmxInput'
                 ].includes(key)
             )
           )

--- a/src/store/useStore.ts
+++ b/src/store/useStore.ts
@@ -38,6 +38,7 @@ import storeClientIdentity from './ui/storeClientIdentity'
 import storeClients from './api/storeClients'
 import storeVisualizerConfigOptimistic from './ui-persist/storeVisualizerConfigOptimistic'
 import storeSendspin from './api/storeSendspin'
+import storeVenues from './api/storeVenues'
 
 const useStore = create(
   devtools(
@@ -81,7 +82,8 @@ const useStore = create(
           ...storeClients(set),
           ...storeCloud(set),
           ...storeVisualizerConfigOptimistic(set),
-          ...storeSendspin(set)
+          ...storeSendspin(set),
+          ...storeVenues(set)
         })
       ),
       {
@@ -109,7 +111,9 @@ const useStore = create(
                   'spotify',
                   'pixelGraphs',
                   'externalStudioRef',
-                  'clientIdentity'
+                  'clientIdentity',
+                  'activeVenueId',
+                  'activeOverridePadIndex'
                 ].includes(key)
             )
           )


### PR DESCRIPTION
## Summary

Adds a **DMX Input** integration settings UI: a SoundSwitch/Art-Net bridge that maps incoming DMX channels to LedFx actions — trigger a venue color-override pad, pass a live RGB value straight through to a virtual/venue, or drive a virtual as a dumb DMX wash fixture (mode/dimmer/RGB channels).

- Integration card (status switch, live status text, settings gear) alongside the other integrations (Spotify, MQTT, HA, ...).
- Full-screen **DMX Input Mappings** settings screen: add/edit/delete channel mappings (Trigger / Color / Fixture types), each targeting either a Venue (+ optional pad) or a Virtual.
- Live DMX monitor + "learn channel" helper for wiring up SoundSwitch/Art-Net without guessing channel numbers.

## Stacking / dependency note

This branch is stacked on `feat/venues-color-override` (#133) because the DMX trigger/color mapping types target Venues and their color-override pads. **This diff currently includes both the Venues changes and the DMX changes.** Once #133 merges into `main`, this branch will be rebased onto `main` and the diff will shrink to just the DMX Input commit.

It also depends on the backend implementation in **LedFx/LedFx#1839** (draft, stacked on the Venues backend PR) — the DMX Input API (`/api/integrations` type `dmx_input`, Art-Net listener, channel-learn endpoint) isn't merged upstream yet either.

Marking this **draft** until both #133 and LedFx/LedFx#1839 are ready to land.

## Test coverage

- New `playwright/tests/dmx-input.spec.ts`: creates a virtual, enables the Integrations feature flag (Expert Mode → Features → Integrations), adds a DMX Input integration, activates it and confirms it starts listening, configures a Fixture-mode mapping targeting the virtual, and verifies it saves and displays correctly in the mappings table.
- Confirmed the full existing Playwright suite still passes with this branch: `add-virtual`, `matrix-device`, `venues`, and the new `dmx-input` spec all pass (both individually and in a full serial run). `visualiser-features.spec.ts` shows the same pre-existing cross-spec test-isolation flakiness noted on #133 (passes reliably in isolation) — unrelated to this change.
- `yarn test:types` passes; `yarn test:lint` shows only the same 5 pre-existing baseline errors present on a clean `main` checkout (no new issues introduced).